### PR TITLE
ci: build Go binaries in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    outputs:
+      new_release: ${{ steps.semantic.outputs.new_release_published }}
+      version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,3 +65,60 @@ jobs:
           TAG="v${VERSION}"
           mv pentest-kit-snapshot.tar.gz "pentest-kit-${TAG}.tar.gz"
           gh release upload "$TAG" "pentest-kit-${TAG}.tar.gz" --clobber
+
+  go-binaries:
+    name: Build Go CLI Binaries
+    needs: release
+    if: needs.release.outputs.new_release == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Test
+        working-directory: pentest-kit-cli
+        run: |
+          go vet ./...
+          go test ./... -count=1
+
+      - name: Build binaries
+        working-directory: pentest-kit-cli
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          LDFLAGS="-s -w -X main.version=${VERSION}"
+
+          for GOOS in linux darwin; do
+            for GOARCH in amd64 arm64; do
+              echo "Building ${GOOS}/${GOARCH}..."
+              GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 \
+                go build -ldflags "$LDFLAGS" -trimpath \
+                -o "pentest-kit-${GOOS}-${GOARCH}/pentest-kit" \
+                ./cmd/pentest-kit/
+              tar -czf "pentest-kit-${GOOS}-${GOARCH}.tar.gz" \
+                "pentest-kit-${GOOS}-${GOARCH}/pentest-kit"
+            done
+          done
+
+          # Checksums
+          sha256sum pentest-kit-*.tar.gz > checksums.txt
+
+      - name: Upload to release
+        working-directory: pentest-kit-cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.release.outputs.version }}"
+          gh release upload "$TAG" pentest-kit-*.tar.gz checksums.txt --clobber
+
+      - name: Summary
+        run: |
+          echo "## Go CLI Binaries" >> $GITHUB_STEP_SUMMARY
+          echo "Version: v${{ needs.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          ls -la pentest-kit-cli/pentest-kit-*.tar.gz >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Moved Go binary building into the release workflow instead of a separate tag-triggered workflow.

**Problem:** `GITHUB_TOKEN` can't trigger other workflows. Semantic release creates tags via API, so `create` and `push tags` events never fire for build-cli.yml.

**Fix:** Added `go-binaries` job to release.yml that runs after semantic release on main. Builds linux/darwin × amd64/arm64, uploads to the GitHub release.

## Expected result

After merge → semantic release creates tag → go-binaries job builds and uploads:
- `pentest-kit-linux-amd64.tar.gz`
- `pentest-kit-linux-arm64.tar.gz`
- `pentest-kit-darwin-amd64.tar.gz`
- `pentest-kit-darwin-arm64.tar.gz`
- `checksums.txt`