### PR TITLE
fix(cli): subfinder uses -json not -jsonl, add jq pipe for httpx

### DIFF
--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -298,7 +298,7 @@ func statusCmd() *cobra.Command {
 // pipelineTools maps pipeline names to the command executed inside the container.
 // Placeholders {target} and {eng} are replaced with actual values at runtime.
 var pipelineTools = map[string][]string{
-	"recon":       {"bash", "-c", "subfinder -d {target} -silent -jsonl -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json && cat /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json | httpx -silent -status-code -title -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/httpx.json"},
+	"recon":       {"bash", "-c", "subfinder -d {target} -silent -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json && cat /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json | jq -r '.host' | httpx -silent -status-code -title -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/httpx.json"},
 	"webapp-scan": {"bash", "-c", "nuclei -u {target} -severity critical,high,medium -jsonl -o /pentest-kit/results/{eng}/scans/vulnerability/nuclei/nuclei-full.json"},
 	"injection":   {"bash", "-c", "sqlmap -u '{target}' --batch --level 1 --risk 1 --output-dir=/pentest-kit/results/{eng}/scans/injection/sqlmap/"},
 	"auth":        {"bash", "-c", "hydra -L /usr/share/seclists/Usernames/top-usernames-shortlist.txt -P /usr/share/seclists/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt {target} http-form-post '/login:user=^USER^&pass=^PASS^:F=incorrect' -o /pentest-kit/results/{eng}/scans/auth/hydra/hydra-results.txt"},

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -32,7 +32,7 @@ all_sources:
   parse: "sort -u"
 
 json:
-  template: "subfinder -d {domain} -all -silent -jsonl -o {output_file}"
+  template: "subfinder -d {domain} -all -silent -json -o {output_file}"
   output: "json"
   parse: "jq -r '.host' {output_file} | sort -u"
 ```


### PR DESCRIPTION
## Summary

Fix recon pipeline crash — subfinder doesn't recognize `-jsonl` flag.

## Changes

- `main.go`: subfinder `-jsonl` → `-json` in recon pipeline
- `main.go`: add `jq -r '.host'` pipe between subfinder and httpx (httpx expects plain URLs, not JSON)
- `REGISTRY.md`: fix subfinder json command template

## Test plan

- [x] `go build` — compiles
- [x] `go test ./...` — 39/39 passing
- [ ] `pentest-kit scan recon --target demo.owasp-juice.shop` — needs Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)