### PR TITLE
docs(specs): add skill critique issues from field test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Executors never attack directly — they run free external tools, parse output, 
 | [specs/GIT-WORKFLOW.md](specs/GIT-WORKFLOW.md) | Branches, commits, PRs, semantic release |
 | [specs/ROADMAP.md](specs/ROADMAP.md) | Feature roadmap, milestones, backlog |
 | [specs/SHANNON-COMPARISON.md](specs/SHANNON-COMPARISON.md) | Shannon comparison, gaps, adoption plan |
+| [specs/SKILL-CRITIQUE-ISSUES.md](specs/SKILL-CRITIQUE-ISSUES.md) | 14 issues from field test, prioritized fix plan |
 
 ## Git Workflow (MANDATORY)
 

--- a/specs/SKILL-CRITIQUE-ISSUES.md
+++ b/specs/SKILL-CRITIQUE-ISSUES.md
@@ -1,0 +1,317 @@
+# Skill Critique Issues
+
+> Issues discovered during real-world skill usage (pentest engagement via `/pentest-kit`).
+> Each issue is categorized, prioritized, and has an implementation plan.
+> Reference: field test against live targets using the auto-mode workflow.
+
+---
+
+## Scorecard (Current State)
+
+| Area | Score | Target |
+|------|-------|--------|
+| Skill documentation | 8/10 | 9/10 |
+| CLI core (init, proxy, exec) | 7/10 | 9/10 |
+| CLI pipelines (scan) | 2/10 | 8/10 |
+| CLI reports (report generate) | 2/10 | 8/10 |
+| Tool compatibility | 5/10 | 8/10 |
+| Report templates | 9/10 | 9/10 |
+| Error handling/recovery | 3/10 | 7/10 |
+| End-to-end workflow | 4/10 | 8/10 |
+
+---
+
+## P0 — Broken (Must Fix)
+
+### Issue 1: Scan pipelines don't work
+
+**Problem:** `pentest-kit scan recon` fails with `flag provided but not defined: -jsonl`.
+All pipelines in `pipelineTools` map have flag errors or incompatibilities.
+
+**Status:** Partially fixed — subfinder `-jsonl` → `-json` in PR #31.
+Remaining: need to audit ALL pipeline commands against actual container tool versions.
+
+**Fix:**
+1. Start container, run each pipeline command manually inside it
+2. Fix every flag that doesn't match the installed tool version
+3. Add integration test: `pentest-kit scan <pipeline> --target <test-target>` for each pipeline
+4. Add `--dry-run` flag that prints the command without executing
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go` (pipelineTools map)
+
+---
+
+### Issue 2: `report generate` can't find engagements
+
+**Problem:** CLI looks in `~/.pentest-kit/results/` but engagement was created in `{cwd}/results/`.
+The `ResultsDir()` function in engage.go returns cwd-based path for `init` but `report generate`
+uses workspace-based path.
+
+**Root cause:** `report.go` line 509: `filepath.Join(workspace, "results", engagement)` —
+hardcodes workspace path instead of using `engage.ResultsDir(workspace)`.
+
+**Fix:**
+```go
+// report.go — Generate and GenerateFromFindings
+// Change:
+base := filepath.Join(workspace, "results", engagement)
+// To:
+base := filepath.Join(engage.ResultsDir(workspace), engagement)
+```
+
+**Files:** `pentest-kit-cli/internal/report/report.go`
+
+---
+
+### Issue 3: state.json stuck on "failed" with no recovery
+
+**Problem:** When `scan recon` fails, state.json phase = "failed". Manual scans succeed but
+state isn't updated. No way to reset or update phase.
+
+**Fix:**
+1. Add `pentest-kit engage update <engagement> --phase <phase>` command
+2. Add `pentest-kit engage reset <engagement>` — sets phase back to "init", clears failed pipelines
+3. Make `pentest-kit scan` update state even when run manually after a failure
+4. Auto-detect scan output files and update pipeline status accordingly
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go`, `pentest-kit-cli/internal/engage/engage.go`
+
+---
+
+## P1 — Tool Compatibility
+
+### Issue 4: httpx flags wrong
+
+**Problem:** Container has httpx v1.1.5 (httpx-toolkit). Pipeline/docs pass `-u` flag but
+this version uses stdin or `-l` for input. Also `-cdn` causes DNS crash.
+
+**Fix:**
+1. Audit httpx flags in container: `pentest-kit exec httpx -h`
+2. Update REGISTRY.md httpx commands
+3. Update recon pipeline to pipe input via stdin (already fixed in PR #31 with `jq | httpx`)
+4. Remove `-cdn` from any pipeline/doc commands
+5. Add httpx version note to TOOLS.md quirks section
+
+**Files:** `tools/REGISTRY.md`, `specs/TOOLS.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 5: testssl.sh fails through proxychains
+
+**Problem:** SSL handshake can't go through SOCKS5 proxy. testssl always fails via proxychains.
+
+**Fix:**
+1. Document limitation in `specs/PROXY.md`: "testssl must run without proxy"
+2. Update ssl pipeline to skip proxychains automatically:
+   ```go
+   "ssl": {"bash", "-c", "testssl --jsonfile ... {target}"}  // no proxychains prefix
+   ```
+3. Add `proxy_compatible: false` field to tool registry for tools that can't use proxy
+4. `pentest-kit scan ssl` should auto-skip proxy even when enabled
+
+**Files:** `specs/PROXY.md`, `specs/TOOLS.md`, `tools/REGISTRY.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 6: No `--no-proxy` flag for `pentest-kit exec`
+
+**Problem:** Once proxy is enabled, ALL exec commands go through proxychains.
+Some tools (httpx, testssl, nuclei) work poorly through Tor.
+
+**Fix:**
+Add `--no-proxy` / `--direct` flag to exec:
+```go
+// pentest-kit exec --no-proxy testssl https://target.com
+// Runs command without proxychains prefix
+```
+
+Also add per-pipeline proxy config:
+```go
+pipelineTools["ssl"].ProxyRequired = false
+```
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go`, `pentest-kit-cli/internal/docker/docker.go`
+
+---
+
+### Issue 7: katana and gau produce empty output through Tor
+
+**Problem:** URL discovery tools return 0 results through proxychains/Tor.
+Tools silently fail — no error, just empty files.
+
+**Fix:**
+1. Pipeline orchestration should check output file size after each step
+2. If output is empty, warn and optionally retry without proxy
+3. Add `--retry-without-proxy` behavior for discovery tools
+4. Document in PROXY.md which tools degrade through Tor
+
+**Files:** `specs/PROXY.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+## P2 — Skill Document Issues
+
+### Issue 8: Auto-mode workflow is aspirational
+
+**Problem:** The documented workflow `Init → Proxy → Recon → Plan → Test → Aggregate → Report`
+doesn't work end-to-end. scan fails, report generate fails, findings.json doesn't exist.
+
+**Fix:**
+1. Fix P0 issues first (pipelines, report path, state recovery)
+2. Then update SKILL.md workflow to reflect what actually works
+3. Add a "Manual Fallback" section: if scan pipeline fails, here's how to run tools directly
+4. Add end-to-end integration test that runs the full workflow
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`
+
+---
+
+### Issue 9: Executor agents section is confusing
+
+**Problem:** Skill recommends deploying executor subagents but then says "if that doesn't work,
+run from orchestrator directly." In practice, orchestrator-direct is the only reliable path.
+
+**Fix:** Update SKILL.md to be opinionated:
+- **Primary pattern:** orchestrator runs `pentest-kit exec` directly
+- **Optional:** deploy parallel executor subagents for independent pipelines
+- Remove the hedging language
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`, `.claude/agents/orchestrator.md`
+
+---
+
+### Issue 10: Missing "what to do when tools fail" guidance
+
+**Problem:** Error handling section is thin. Real failures are flag incompatibilities,
+proxy issues, and DNS resolution — preflight doesn't catch these.
+
+**Fix:** Add troubleshooting section to SKILL.md:
+```markdown
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `flag provided but not defined` | Tool version mismatch | Check `pentest-kit exec <tool> -h` |
+| Empty output file | Proxy blocking tool | Retry with `--no-proxy` |
+| `DNS lookup failed` | Tor DNS resolution | Use `-cdn false` or direct connection |
+| `connection refused` | Target down | Run `pentest-kit preflight --target <url>` |
+| state.json stuck on "failed" | Pipeline crashed | `pentest-kit engage reset <eng>` |
+```
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`
+
+---
+
+## P3 — CLI Enhancements
+
+### Issue 11: Add `pentest-kit exec --save <label>`
+
+**Problem:** Output paths are long and error-prone.
+`pentest-kit exec nmap ... -oX /pentest-kit/results/{eng}/scans/reconnaissance/raw/nmap.xml`
+
+**Fix:** Add `--save` shorthand:
+```bash
+pentest-kit exec --save recon/nmap nmap -sV target.com -oX {auto}
+# auto-resolves to /pentest-kit/results/{latest-eng}/scans/reconnaissance/raw/nmap.xml
+```
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go`, `pentest-kit-cli/internal/docker/docker.go`
+
+---
+
+### Issue 12: findings.json should be built incrementally
+
+**Problem:** findings.json must be manually written at the end. No way to add findings one at a time.
+
+**Fix:** Add CLI commands:
+```bash
+pentest-kit finding add \
+  --id FIND-001 \
+  --severity HIGH \
+  --title "SQL Injection in login" \
+  --endpoint "/api/auth" \
+  --tool sqlmap \
+  --poc "sqlmap -u 'https://target/api/auth?user=1' --batch"
+
+pentest-kit finding list          # show all findings
+pentest-kit finding export        # write findings.json
+```
+
+**Files:** New `pentest-kit-cli/internal/finding/finding.go`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 13: Report section auto-generation from findings.json
+
+**Problem:** `report generate` exists and works from findings.json, but the user didn't know.
+The skill doc doesn't make the `report generate` → template flow explicit.
+
+**Fix:**
+1. Fix the path resolution bug (Issue 2) so `report generate` actually works
+2. Make SKILL.md auto-mode workflow explicitly say: "run `pentest-kit report generate <eng>`"
+3. Add `pentest-kit report preview <eng>` that shows which sections would be generated
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 14: Better `pentest-kit engage status` output
+
+**Problem:** Status output is basic. Should show scan coverage and finding counts.
+
+**Fix:** Enhance status output:
+```
+Engagement: beleka-tekadesa
+Target:     https://desa.beleka.tekadesa.com
+Phase:      testing
+
+Scans:  recon ✓  vuln ✓  injection ✓  ssl ✗  sast N/A  sca N/A
+Findings: 1 HIGH, 3 MEDIUM, 4 LOW, 3 OBS
+Report: not generated
+
+Pipelines:
+  ✓ recon: complete (12 findings)
+  ✓ webapp-scan: complete (5 findings)
+  ✗ ssl: failed (testssl proxy incompatible)
+  – sast: skipped (no --source)
+```
+
+**Files:** `pentest-kit-cli/internal/engage/engage.go`
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (Fix broken things):
+  Issue 2  → report path resolution (quick fix, 1 line)
+  Issue 3  → engage update/reset commands
+  Issue 1  → audit all pipeline flags in container
+
+Phase 2 (Tool compat):
+  Issue 5  → testssl proxy skip
+  Issue 6  → --no-proxy flag
+  Issue 4  → httpx flag audit
+  Issue 7  → empty output detection
+
+Phase 3 (Skill doc):
+  Issue 8  → update auto-mode workflow
+  Issue 9  → simplify executor section
+  Issue 10 → add troubleshooting table
+
+Phase 4 (Enhancements):
+  Issue 12 → incremental findings
+  Issue 14 → better engage status
+  Issue 11 → exec --save shorthand
+  Issue 13 → report preview
+```
+
+---
+
+## Cross-References
+
+- Pipeline flag fixes → `tools/REGISTRY.md` (source of truth for tool commands)
+- Proxy compatibility → `specs/PROXY.md`
+- Tool quirks → `specs/TOOLS.md`
+- Shannon adoption → `specs/SHANNON-COMPARISON.md` (P0: connectivity pre-check, resume)
+- Report system → `specs/REPORTS.md`


### PR DESCRIPTION
## Summary

Add `specs/SKILL-CRITIQUE-ISSUES.md` — 14 issues from real pentest engagement, with scorecard, root cause analysis, and implementation plan.

## Scorecard

| Area | Current | Target |
|------|---------|--------|
| CLI pipelines | 2/10 | 8/10 |
| CLI reports | 2/10 | 8/10 |
| Error handling | 3/10 | 7/10 |
| End-to-end workflow | 4/10 | 8/10 |

## Issues by priority

**P0 (Broken):** scan pipelines fail, report generate path bug, state.json stuck
**P1 (Tool compat):** httpx flags, testssl proxy, no --no-proxy, empty output detection
**P2 (Docs):** auto-mode workflow, executor section, troubleshooting table
**P3 (Enhancements):** exec --save, incremental findings, report preview, better status

## Test plan

- [x] Every issue has root cause, fix plan, and affected files listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)