### PR TITLE
fix(cli): P0 fixes — report path, engage reset, exec --no-proxy

### DIFF
--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -156,11 +156,11 @@ func shellCmd() *cobra.Command {
 	}
 }
 
-// pentest-kit exec <command...>
+// pentest-kit exec [--no-proxy] <command...>
 func execCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:                "exec [command...]",
-		Short:              "Run a command inside the container",
+		Use:                "exec [--no-proxy] [command...]",
+		Short:              "Run a command inside the container (--no-proxy to skip proxychains)",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -169,6 +169,14 @@ func execCmd() *cobra.Command {
 			ws, err := docker.FindWorkspace()
 			if err != nil {
 				return err
+			}
+			// Handle --no-proxy flag (since DisableFlagParsing is true, parse manually)
+			if args[0] == "--no-proxy" || args[0] == "--direct" {
+				if len(args) < 2 {
+					return fmt.Errorf("usage: pentest-kit exec --no-proxy <command>")
+				}
+				// Set env var so proxychains is skipped inside container
+				return docker.ExecWithEnv(ws, args[1:], []string{"PENTEST_KIT_NO_PROXY=1"})
 			}
 			return docker.Exec(ws, args)
 		},
@@ -274,6 +282,48 @@ func engageCmd() *cobra.Command {
 				name = args[0]
 			}
 			return engage.Status(ws, name)
+		},
+	})
+
+	// pentest-kit engage update <engagement> --phase <phase>
+	var phase string
+	updateCmd := &cobra.Command{
+		Use:   "update <engagement>",
+		Short: "Update engagement phase manually",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := docker.FindWorkspace()
+			if err != nil {
+				return err
+			}
+			if phase == "" {
+				return fmt.Errorf("--phase is required (init, scanning, testing, complete, failed)")
+			}
+			if err := engage.UpdatePhase(ws, args[0], phase); err != nil {
+				return err
+			}
+			fmt.Printf("  ✓ %s phase → %s\n", args[0], phase)
+			return nil
+		},
+	}
+	updateCmd.Flags().StringVar(&phase, "phase", "", "New phase (init, scanning, testing, complete, failed)")
+	cmd.AddCommand(updateCmd)
+
+	// pentest-kit engage reset <engagement>
+	cmd.AddCommand(&cobra.Command{
+		Use:   "reset <engagement>",
+		Short: "Reset engagement — clear failed pipelines, set phase back to init",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := docker.FindWorkspace()
+			if err != nil {
+				return err
+			}
+			if err := engage.Reset(ws, args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("  ✓ %s reset to init phase\n", args[0])
+			return nil
 		},
 	})
 

--- a/pentest-kit-cli/internal/docker/docker.go
+++ b/pentest-kit-cli/internal/docker/docker.go
@@ -139,11 +139,23 @@ func Down(workspace string) error {
 
 // Exec runs a command inside the container.
 func Exec(workspace string, args []string) error {
+	return ExecWithEnv(workspace, args, nil)
+}
+
+// ExecWithEnv runs a command inside the container with optional extra environment variables.
+func ExecWithEnv(workspace string, args []string, envVars []string) error {
 	if !IsRunning(workspace) {
 		return fmt.Errorf("container not running. Run: pentest-kit up")
 	}
 
-	dockerArgs := append([]string{"compose", "exec", "-T", "pentest-kit"}, args...)
+	// Build docker compose exec command with optional -e flags
+	dockerArgs := []string{"compose", "exec", "-T"}
+	for _, e := range envVars {
+		dockerArgs = append(dockerArgs, "-e", e)
+	}
+	dockerArgs = append(dockerArgs, "pentest-kit")
+	dockerArgs = append(dockerArgs, args...)
+
 	cmd := exec.Command("docker", dockerArgs...)
 	cmd.Dir = workspace
 	cmd.Stdout = os.Stdout

--- a/pentest-kit-cli/internal/engage/engage.go
+++ b/pentest-kit-cli/internal/engage/engage.go
@@ -39,8 +39,8 @@ type FindingsCount struct {
 }
 
 // Init creates a new engagement directory with the full structure.
-// ResultsDir returns the results directory — cwd/results/ if it exists or can be created,
-// otherwise falls back to workspace/results/.
+// ResultsDir returns the results directory — checks cwd/results/ first,
+// then workspace/results/, falls back to cwd/results/ for new engagements.
 func ResultsDir(workspace string) string {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -53,11 +53,10 @@ func ResultsDir(workspace string) string {
 		return cwdResults
 	}
 
-	// If cwd is the workspace, use workspace/results/
-	absWs, _ := filepath.Abs(workspace)
-	absCwd, _ := filepath.Abs(cwd)
-	if absWs == absCwd {
-		return filepath.Join(workspace, "results")
+	// If workspace has a results/ dir, use it (covers report generate from different cwd)
+	wsResults := filepath.Join(workspace, "results")
+	if info, err := os.Stat(wsResults); err == nil && info.IsDir() {
+		return wsResults
 	}
 
 	// Otherwise use cwd/results/ (will be created by Init)
@@ -368,6 +367,22 @@ func UpdateFindings(workspace, engagement string, counts FindingsCount) error {
 		return fmt.Errorf("failed to read state for %q: %w", engagement, err)
 	}
 	state.Findings = counts
+	return writeJSON(statePath, state)
+}
+
+// Reset clears failed/running pipelines and sets phase back to init.
+func Reset(workspace, engagement string) error {
+	statePath := filepath.Join(ResultsDir(workspace), engagement, "state.json")
+	state, err := readState(statePath)
+	if err != nil {
+		return fmt.Errorf("engagement %q not found or missing state.json", engagement)
+	}
+	state.Phase = "init"
+	for name, p := range state.Pipelines {
+		if p.Status == "failed" || p.Status == "running" {
+			state.Pipelines[name] = &Pipeline{Status: "pending"}
+		}
+	}
 	return writeJSON(statePath, state)
 }
 

--- a/pentest-kit-cli/internal/engage/engage_test.go
+++ b/pentest-kit-cli/internal/engage/engage_test.go
@@ -386,3 +386,55 @@ func TestReadWriteState(t *testing.T) {
 		t.Errorf("expected 1 critical finding, got %d", loaded.Findings.Critical)
 	}
 }
+
+func TestReset(t *testing.T) {
+	workspace := t.TempDir()
+	chdir(t, workspace)
+
+	// Create engagement with failed state
+	err := Init(workspace, "reset-test", "https://example.com", "")
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	// Set phase to failed and add failed/complete pipelines
+	_ = UpdatePhase(workspace, "reset-test", "failed")
+	_ = UpdatePipeline(workspace, "reset-test", "recon", "complete", 10)
+	_ = UpdatePipeline(workspace, "reset-test", "webapp-scan", "failed", 0)
+	_ = UpdatePipeline(workspace, "reset-test", "injection", "running", 0)
+
+	// Reset
+	err = Reset(workspace, "reset-test")
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+
+	// Verify state
+	statePath := filepath.Join(ResultsDir(workspace), "reset-test", "state.json")
+	data, _ := os.ReadFile(statePath)
+	var state State
+	json.Unmarshal(data, &state)
+
+	if state.Phase != "init" {
+		t.Errorf("expected phase 'init', got %q", state.Phase)
+	}
+	if state.Pipelines["recon"].Status != "complete" {
+		t.Errorf("recon should stay complete, got %q", state.Pipelines["recon"].Status)
+	}
+	if state.Pipelines["webapp-scan"].Status != "pending" {
+		t.Errorf("webapp-scan should be reset to pending, got %q", state.Pipelines["webapp-scan"].Status)
+	}
+	if state.Pipelines["injection"].Status != "pending" {
+		t.Errorf("injection should be reset to pending, got %q", state.Pipelines["injection"].Status)
+	}
+}
+
+func TestReset_NotFound(t *testing.T) {
+	workspace := t.TempDir()
+	chdir(t, workspace)
+
+	err := Reset(workspace, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent engagement")
+	}
+}

--- a/pentest-kit-cli/internal/report/report.go
+++ b/pentest-kit-cli/internal/report/report.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/docker"
+	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/engage"
 )
 
 // ---------------------------------------------------------------------------
@@ -506,7 +507,7 @@ func GenerateFromFindings(workspace, engagement string) error {
 		return fmt.Errorf("usage: pentest-kit report generate <engagement>")
 	}
 
-	base := filepath.Join(workspace, "results", engagement)
+	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	if _, err := os.Stat(base); err != nil {
 		return fmt.Errorf("engagement %q not found at %s", engagement, base)
 	}
@@ -572,7 +573,7 @@ func Generate(workspace, engagement string) error {
 		return fmt.Errorf("usage: pentest-kit report generate <engagement>")
 	}
 
-	base := filepath.Join(workspace, "results", engagement)
+	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	if _, err := os.Stat(base); err != nil {
 		return fmt.Errorf("engagement %q not found at %s", engagement, base)
 	}
@@ -670,7 +671,7 @@ func Status(workspace, engagement string) error {
 		return fmt.Errorf("usage: pentest-kit report status <engagement>")
 	}
 
-	base := filepath.Join(workspace, "results", engagement)
+	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	rawDir := filepath.Join(base, "reports", "raw")
 	finalDir := filepath.Join(base, "reports", "final")
 


### PR DESCRIPTION
## Summary

Fix the 3 most critical issues from field test critique.

## Fixes

### Issue 2: `report generate` can't find engagements
- `Generate`, `GenerateFromFindings`, `Status` now use `engage.ResultsDir()` 
- `ResultsDir()` checks workspace/results/ as fallback when cwd/results/ doesn't exist

### Issue 3: state.json stuck on "failed"
- New `pentest-kit engage update <eng> --phase <phase>` — manually set phase
- New `pentest-kit engage reset <eng>` — clear failed/running pipelines, reset to init

### Issue 6: No `--no-proxy` flag
- New `pentest-kit exec --no-proxy <cmd>` — skips proxychains
- New `ExecWithEnv()` in docker.go — passes env vars to container

## Test plan

- [x] `go test ./...` — 43/43 passing
- [x] 2 new tests: TestReset, TestReset_NotFound
- [x] `go build` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)