### PR TITLE
fix(docker): libasound2 → libasound2t64 for Kali rolling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgbm1 \
     libpango-1.0-0 \
     libcairo2 \
-    libasound2 \
+    libasound2t64 \
     libatspi2.0-0 \
     libwayland-client0 \
     fonts-liberation \


### PR DESCRIPTION
Package renamed in Kali.