### PR TITLE
fix(docker): set NODE_PATH for global playwright module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Playwright and Chromium browser
+ENV NODE_PATH=/usr/lib/node_modules
 RUN npm install -g playwright && \
     npx playwright install chromium && \
     npx playwright install-deps chromium


### PR DESCRIPTION
node -e require('playwright') fails because npm install -g puts modules in /usr/lib/node_modules but Node doesn't check there by default. Set NODE_PATH=/usr/lib/node_modules.