### PR TITLE
fix(docker): install playwright locally in /opt/playwright

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,19 +192,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Playwright and Chromium browser
-RUN npm install -g playwright && \
+# Install Playwright locally (not global — avoids NODE_PATH issues)
+WORKDIR /opt/playwright
+RUN npm init -y && \
+    npm install playwright && \
     npx playwright install chromium && \
     npx playwright install-deps chromium
 
 # Verify Playwright works headless
-RUN node -e "const { chromium } = require('playwright'); \
+RUN cd /opt/playwright && node -e "const { chromium } = require('playwright'); \
     (async () => { \
       const browser = await chromium.launch({ headless: true }); \
       const page = await browser.newPage(); \
       console.log('Playwright OK — Chromium headless works'); \
       await browser.close(); \
     })();"
+
+# Set NODE_PATH so playwright can be required from anywhere
+ENV NODE_PATH=/opt/playwright/node_modules
 
 # ============================================
 # Layer 7: Update nuclei templates


### PR DESCRIPTION
Global npm install puts modules where Node can't find them. Install locally with npm init + npm install in /opt/playwright. Set NODE_PATH=/opt/playwright/node_modules.