### PR TITLE
fix(cli): report generate validates findings.json before raw sections

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -175,8 +175,10 @@ pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json 
 5. pentest-kit scan webapp-scan --target <url>      ← vuln scanning
    pentest-kit scan injection --target <url>        ← injection testing
    pentest-kit scan ssl --target <url>              ← SSL (auto-skips proxy)
-6. Write findings.json from confirmed results
-7. pentest-kit report generate <eng>                ← generates report from findings.json
+6. Create scripts/ with PoC scripts for confirmed vulns
+7. Write findings.json from confirmed results
+8. Write reports/raw/ sections using reference/templates/
+9. pentest-kit report generate <eng>                ← combines raw → final + pandoc
 ```
 
 **If a scan pipeline fails**, fall back to running tools directly:
@@ -197,19 +199,20 @@ Agent processes export (pentest-kit exec nuclei/sqlmap/dalfox) →
 Results → User verifies → Report
 ```
 
-### Copilot Mode (`/pentest-kit copilot`)
+### Copilot Mode (`/pentest-kit copilot`) — NOT YET IMPLEMENTED
 ```
+Planned workflow:
 1. pentest-kit init <eng> --target <url>
 2. pentest-kit proxy tor
 3. pentest-kit exec mitmdump -p 8081 -s tools/copilot/interceptor.py &
-4. Agent drives Playwright headless inside container:
-   pentest-kit exec node -e "const { chromium } = require('playwright'); ..."
+4. Agent drives Playwright headless inside container
 5. User directs: "login as admin", "try user ID 101", "check XSS on search"
 6. Interceptor logs traffic to copilot/traffic.ndjson, auto-detects findings
 7. Report from copilot/findings.ndjson
 ```
-Playwright + Chromium run headless inside the Docker container.
-mitmproxy interceptor auto-detects IDOR, JWT, sensitive data patterns.
+Status: Playwright + Chromium are installed in the Docker container but copilot
+orchestration (interceptor.py, traffic capture, auto-detect) is not built yet.
+Do NOT attempt copilot mode — use auto or assist mode instead.
 
 ## Results Structure
 
@@ -339,4 +342,4 @@ The CLI does NOT auto-generate content. It only combines and exports what the ag
 - **Evidence from tools**: Save raw tool output as evidence
 - **Working PoCs required**: Every vulnerability needs a reproducible PoC
 - **No theoretical findings**: Tool output must confirm vulnerability
-- **Report via CLI**: `pentest-kit report generate <eng>` reads findings.json → generates report sections → combines → DOCX
+- **Report via CLI**: `pentest-kit report generate <eng>` combines reports/raw/ → final .md + .docx + .pdf (agent writes raw sections first)


### PR DESCRIPTION
## Summary
- `report generate` now validates `findings.json` exists before checking `reports/raw/` sections
- Documents the correct 5-step report flow: scans → scripts → findings → raw → final
- Auto mode workflow updated to show full 9-step flow (was 7 steps, missing scripts/raw)
- Copilot mode explicitly marked as NOT YET IMPLEMENTED with clear warning
- Critical Rules section corrected: report CLI combines raw sections, doesn't auto-generate

## Changes
- `pentest-kit-cli/internal/report/report.go` — added findings.json prerequisite check with helpful error messages
- `.claude/skills/pentest-kit/SKILL.md` — corrected auto mode steps, copilot status, report description

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (3 packages)
- [ ] Manual: `pentest-kit report generate` without findings.json shows step guide
- [ ] Manual: `pentest-kit report generate` with findings.json but no raw sections shows section guide