### PR TITLE
Release v0.12.0 — Go CLI, Docker Playwright, specs, critique fixes

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -152,8 +152,8 @@ pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json 
 
 1. **Executors NEVER attack directly.** They run tools from `tools/REGISTRY.md` following `tools/PIPELINES.md`.
 2. **All tools run inside the Docker container.** Use `pentest-kit exec <command>`. Never run tools on the host.
-3. **Proxy before scanning.** Always `pentest-kit proxy tor` (or socks5/http) before any network activity.
-4. **Executor agents:** Deploy with `mode="bypassPermissions"`. If subagents still can't run Bash, run commands directly from the orchestrator using `pentest-kit exec` instead of deploying subagents.
+3. **Proxy before scanning.** Always `pentest-kit proxy tor` (or socks5/http) before network scanning. Exception: `ssl` and `sast`/`sca` pipelines skip proxy automatically.
+4. **Run tools from orchestrator directly** using `pentest-kit exec`. This is the primary pattern. Deploying parallel executor subagents is optional for independent pipelines.
 
 ## Startup Sequence (ALL MODES)
 
@@ -168,8 +168,26 @@ pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json 
 
 ### Auto Mode (`/pentest-kit`)
 ```
-Init → Proxy → Recon (pentest-kit scan recon) → Plan (user approval) →
-Test (parallel pipelines) → Aggregate (findings.json) → Report (pentest-kit report generate)
+1. pentest-kit init <eng> --target <url>           ← bootstrap
+2. pentest-kit proxy tor && pentest-kit proxy status ← mandatory
+3. pentest-kit scan recon --target <domain>         ← asset discovery
+4. Analyze recon output, present plan, GET USER APPROVAL
+5. pentest-kit scan webapp-scan --target <url>      ← vuln scanning
+   pentest-kit scan injection --target <url>        ← injection testing
+   pentest-kit scan ssl --target <url>              ← SSL (auto-skips proxy)
+6. Write findings.json from confirmed results
+7. pentest-kit report generate <eng>                ← generates report from findings.json
+```
+
+**If a scan pipeline fails**, fall back to running tools directly:
+```bash
+# Instead of: pentest-kit scan recon --target example.com
+# Run tools individually:
+pentest-kit exec subfinder -d example.com -silent -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json
+pentest-kit exec nmap -sV example.com -oX /pentest-kit/results/{eng}/scans/reconnaissance/raw/nmap.xml
+
+# Reset stuck state:
+pentest-kit engage reset <eng>
 ```
 
 ### Assist Mode (`/pentest-kit assist`)
@@ -181,10 +199,17 @@ Results → User verifies → Report
 
 ### Copilot Mode (`/pentest-kit copilot`)
 ```
-Init → Proxy → Agent starts mitmproxy interceptor → Agent drives Playwright →
-User directs ("login as admin", "try ID 101") → Interceptor auto-detects vulns →
-Traffic logged as NDJSON → Report
+1. pentest-kit init <eng> --target <url>
+2. pentest-kit proxy tor
+3. pentest-kit exec mitmdump -p 8081 -s tools/copilot/interceptor.py &
+4. Agent drives Playwright headless inside container:
+   pentest-kit exec node -e "const { chromium } = require('playwright'); ..."
+5. User directs: "login as admin", "try user ID 101", "check XSS on search"
+6. Interceptor logs traffic to copilot/traffic.ndjson, auto-detects findings
+7. Report from copilot/findings.ndjson
 ```
+Playwright + Chromium run headless inside the Docker container.
+mitmproxy interceptor auto-detects IDOR, JWT, sensitive data patterns.
 
 ## Results Structure
 
@@ -235,22 +260,61 @@ See `reference/ATTACK_INDEX.md` for complete list.
 - `reference/ATTACK_INDEX.md` — attack type index
 - `reference/CAIDO_INTEGRATION.md` — manual proxy workflow
 
-## Error Handling
+## Findings Format
 
-- **Tool fails:** Check `pentest-kit preflight --deep` for version/flag issues
-- **Proxy drops:** `pentest-kit proxy status` to check, `pentest-kit proxy tor` to restart
-- **Container stops:** `pentest-kit up` to restart, state.json preserves progress
-- **Permission denied:** Run commands from orchestrator directly, not subagents
-- **Wrong paths:** All container paths start with `/pentest-kit/`. Never use host paths in exec commands.
+Two types of findings in `findings.json`:
+
+- **Vulnerability** (`type: "vulnerability"`) — exploitable, tool-confirmed, has working PoC, gets CVSS + difficulty rating
+- **Observation** (`type: "observation"`) — hardening advice, not exploitable, no PoC needed, severity = "info"
+
+Every vulnerability MUST have:
+- Confirmed by tool output (not theoretical)
+- Copy-paste reproducible PoC
+- Evidence in `evidence/FIND-{NNN}/`
+
+## Report Generation
+
+The report is a **two-step process**:
+
+**Step 1 (Agent):** Read templates from `reference/templates/`, fill with findings data, write numbered sections to `reports/raw/`:
+```
+Read reference/templates/COVER-AND-SCOPE.md → fill → write reports/raw/01-COVER-AND-SCOPE.md
+Read reference/templates/EXECUTIVE-SUMMARY.md → fill → write reports/raw/02-EXECUTIVE-SUMMARY.md
+Read reference/templates/FINDINGS.md → fill → write reports/raw/03-FINDINGS.md
+...
+```
+
+**Step 2 (CLI):** Combine raw sections into final deliverables:
+```bash
+pentest-kit report generate <engagement>
+# → combines reports/raw/*.md into reports/final/Penetration-Test-Report.md
+# → runs pandoc for .docx and .pdf
+```
+
+The CLI does NOT auto-generate sections — it only combines what the agent wrote. If `reports/raw/` is empty, it tells you to write sections first.
+
+## Error Handling & Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `flag provided but not defined` | Tool version mismatch | Check `pentest-kit exec <tool> -h` for available flags |
+| Empty output file (0 results) | Proxy blocking tool | Retry with `pentest-kit exec --no-proxy <cmd>` |
+| `DNS lookup failed` / `-cdn` crash | httpx flag incompatible | Remove `-cdn` flag, use stdin instead of `-u` |
+| `connection refused` / timeout | Target down or unreachable | Verify: `pentest-kit exec curl -sv <url>` |
+| testssl always fails | SSL can't go through SOCKS5 | Use `pentest-kit exec --no-proxy testssl <url>` (ssl pipeline auto-skips proxy) |
+| katana/gau return 0 URLs | Tor exit node blocked | Retry without proxy or use direct connection |
+| state.json stuck on "failed" | Pipeline crashed | `pentest-kit engage reset <eng>` |
+| `report generate` can't find engagement | Path mismatch (cwd vs workspace) | Run from same directory where you ran `init`, or check `pentest-kit engage list` |
+| Pipeline succeeds but 0 findings | Tool ran but found nothing | Check raw output in `scans/` directory, not an error |
 
 ## Critical Rules
 
-- **Proxy MANDATORY**: `pentest-kit proxy tor` before any network scanning
+- **Proxy MANDATORY**: `pentest-kit proxy tor` before network scanning (ssl/sast/sca auto-skip)
 - **Preflight MANDATORY**: `pentest-kit preflight` before every engagement
-- **User approval MANDATORY**: Phase 3 requires explicit approval
+- **User approval MANDATORY**: Present test plan and get approval before exploitation
 - **Tool-based only**: All commands from REGISTRY.md, all chains from PIPELINES.md
 - **Container paths**: All exec commands use `/pentest-kit/results/{engagement}/...`
 - **Evidence from tools**: Save raw tool output as evidence
-- **Working PoCs required**: Every finding needs a reproducible PoC
+- **Working PoCs required**: Every vulnerability needs a reproducible PoC
 - **No theoretical findings**: Tool output must confirm vulnerability
-- **Report via CLI**: `pentest-kit report generate` — never write report files via heredoc
+- **Report via CLI**: `pentest-kit report generate <eng>` reads findings.json → generates report sections → combines → DOCX

--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -274,24 +274,46 @@ Every vulnerability MUST have:
 
 ## Report Generation
 
-The report is a **two-step process**:
+The report follows a strict order. Each step depends on the previous one.
 
-**Step 1 (Agent):** Read templates from `reference/templates/`, fill with findings data, write numbered sections to `reports/raw/`:
+**Step 1 — Scans produce tool output:**
+```
+pentest-kit scan recon/webapp-scan/injection/etc → scans/{category}/{tool}/
+```
+
+**Step 2 — Agent creates PoC scripts from confirmed exploits:**
+```
+Write scripts/01-sqli-login.sh, scripts/02-idor-user.sh, etc.
+Write scripts/README.md (dependency tree, prerequisites)
+Write scripts/NN-cleanup.sh (second-to-last)
+Write scripts/NN-verify-remediation.sh (last)
+```
+
+**Step 3 — Agent creates findings.json from confirmed results:**
+```
+Write findings.json at engagement root with all findings + observations.
+Each finding must reference its PoC script and evidence directory.
+```
+
+**Step 4 — Agent writes report sections using templates:**
 ```
 Read reference/templates/COVER-AND-SCOPE.md → fill → write reports/raw/01-COVER-AND-SCOPE.md
 Read reference/templates/EXECUTIVE-SUMMARY.md → fill → write reports/raw/02-EXECUTIVE-SUMMARY.md
 Read reference/templates/FINDINGS.md → fill → write reports/raw/03-FINDINGS.md
-...
+Read reference/templates/REMEDIATION.md → fill → write reports/raw/04-REMEDIATION.md
+Read reference/templates/EVIDENCE-LOG.md → fill → write reports/raw/05-EVIDENCE-LOG.md
+... (additional sections as needed — see reference/FINAL_REPORT.md)
 ```
 
-**Step 2 (CLI):** Combine raw sections into final deliverables:
+**Step 5 — CLI combines raw → final + pandoc:**
 ```bash
 pentest-kit report generate <engagement>
-# → combines reports/raw/*.md into reports/final/Penetration-Test-Report.md
-# → runs pandoc for .docx and .pdf
+# Checks: findings.json exists? reports/raw/ has sections?
+# → combines reports/raw/*.md → reports/final/Penetration-Test-Report.md
+# → pandoc → .docx + .pdf
 ```
 
-The CLI does NOT auto-generate sections — it only combines what the agent wrote. If `reports/raw/` is empty, it tells you to write sections first.
+The CLI does NOT auto-generate content. It only combines and exports what the agent wrote.
 
 ## Error Handling & Troubleshooting
 

--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -175,8 +175,10 @@ pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json 
 5. pentest-kit scan webapp-scan --target <url>      ← vuln scanning
    pentest-kit scan injection --target <url>        ← injection testing
    pentest-kit scan ssl --target <url>              ← SSL (auto-skips proxy)
-6. Write findings.json from confirmed results
-7. pentest-kit report generate <eng>                ← generates report from findings.json
+6. Create scripts/ with PoC scripts for confirmed vulns
+7. Write findings.json from confirmed results
+8. Write reports/raw/ sections using reference/templates/
+9. pentest-kit report generate <eng>                ← combines raw → final + pandoc
 ```
 
 **If a scan pipeline fails**, fall back to running tools directly:
@@ -197,19 +199,20 @@ Agent processes export (pentest-kit exec nuclei/sqlmap/dalfox) →
 Results → User verifies → Report
 ```
 
-### Copilot Mode (`/pentest-kit copilot`)
+### Copilot Mode (`/pentest-kit copilot`) — NOT YET IMPLEMENTED
 ```
+Planned workflow:
 1. pentest-kit init <eng> --target <url>
 2. pentest-kit proxy tor
 3. pentest-kit exec mitmdump -p 8081 -s tools/copilot/interceptor.py &
-4. Agent drives Playwright headless inside container:
-   pentest-kit exec node -e "const { chromium } = require('playwright'); ..."
+4. Agent drives Playwright headless inside container
 5. User directs: "login as admin", "try user ID 101", "check XSS on search"
 6. Interceptor logs traffic to copilot/traffic.ndjson, auto-detects findings
 7. Report from copilot/findings.ndjson
 ```
-Playwright + Chromium run headless inside the Docker container.
-mitmproxy interceptor auto-detects IDOR, JWT, sensitive data patterns.
+Status: Playwright + Chromium are installed in the Docker container but copilot
+orchestration (interceptor.py, traffic capture, auto-detect) is not built yet.
+Do NOT attempt copilot mode — use auto or assist mode instead.
 
 ## Results Structure
 
@@ -339,4 +342,4 @@ The CLI does NOT auto-generate content. It only combines and exports what the ag
 - **Evidence from tools**: Save raw tool output as evidence
 - **Working PoCs required**: Every vulnerability needs a reproducible PoC
 - **No theoretical findings**: Tool output must confirm vulnerability
-- **Report via CLI**: `pentest-kit report generate <eng>` reads findings.json → generates report sections → combines → DOCX
+- **Report via CLI**: `pentest-kit report generate <eng>` combines reports/raw/ → final .md + .docx + .pdf (agent writes raw sections first)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,11 +2,13 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'
       - 'docker-compose.yml'
+      - 'tools/copilot/**'
+      - 'tools/playwright/**'
   release:
     types: [published]
   workflow_dispatch:
@@ -88,7 +90,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.6](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.5...v0.12.0-dev.6) (2026-03-23)
+
+
+### Bug Fixes
+
+* **docker:** set NODE_PATH so global playwright module is found by node ([fd125a8](https://github.com/nunenuh/pentest-kit/commit/fd125a8c715202fe92ddcb28e88502d69ec7b520))
+
 # [0.12.0-dev.5](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.4...v0.12.0-dev.5) (2026-03-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.5](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.4...v0.12.0-dev.5) (2026-03-23)
+
+
+### Bug Fixes
+
+* **docker:** libasound2 renamed to libasound2t64 in Kali rolling ([e1d0e2f](https://github.com/nunenuh/pentest-kit/commit/e1d0e2f463bb42b02582c739e40824c3a3767e1f))
+
 # [0.12.0-dev.4](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.3...v0.12.0-dev.4) (2026-03-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.7](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.6...v0.12.0-dev.7) (2026-03-23)
+
+
+### Bug Fixes
+
+* **docker:** install playwright locally in /opt/playwright instead of global npm ([c4a2424](https://github.com/nunenuh/pentest-kit/commit/c4a2424d4512a2bf5ab35dea436e49e1cb77acba))
+
 # [0.12.0-dev.6](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.5...v0.12.0-dev.6) (2026-03-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.4](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.3...v0.12.0-dev.4) (2026-03-22)
+
+
+### Bug Fixes
+
+* **cli:** remaining critique fixes — pipelines, proxy, report flow, docs ([f8a8f1b](https://github.com/nunenuh/pentest-kit/commit/f8a8f1b222350f3522a1184cec7880eb8bea84dd))
+
 # [0.12.0-dev.3](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.2...v0.12.0-dev.3) (2026-03-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.9](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.8...v0.12.0-dev.9) (2026-03-23)
+
+
+### Bug Fixes
+
+* **skill:** correct auto-mode workflow steps and mark copilot as not implemented ([66298b8](https://github.com/nunenuh/pentest-kit/commit/66298b837a45a3af3dad15ae877827d6e06b667d))
+
 # [0.12.0-dev.8](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.7...v0.12.0-dev.8) (2026-03-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.3](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.2...v0.12.0-dev.3) (2026-03-22)
+
+
+### Bug Fixes
+
+* **cli:** P0 fixes — report path, engage reset, exec --no-proxy ([6243d86](https://github.com/nunenuh/pentest-kit/commit/6243d860fd9d7cd99548f34889adca28b1941eeb))
+
 # [0.12.0-dev.2](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.1...v0.12.0-dev.2) (2026-03-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.2](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.1...v0.12.0-dev.2) (2026-03-22)
+
+
+### Bug Fixes
+
+* **cli:** subfinder uses -json not -jsonl, add jq pipe for httpx ([3e9b607](https://github.com/nunenuh/pentest-kit/commit/3e9b60739a59db84436f8c4303373280015d76a7))
+
 ## [0.11.3](https://github.com/nunenuh/pentest-kit/compare/v0.11.2...v0.11.3) (2026-03-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.12.0-dev.8](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.7...v0.12.0-dev.8) (2026-03-23)
+
+
+### Bug Fixes
+
+* **cli:** report generate validates findings.json before raw sections, document 5-step flow ([0d10bcb](https://github.com/nunenuh/pentest-kit/commit/0d10bcb5b33dc828e652069e242edd3ec8d57ed0))
+
 # [0.12.0-dev.7](https://github.com/nunenuh/pentest-kit/compare/v0.12.0-dev.6...v0.12.0-dev.7) (2026-03-23)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Executors never attack directly — they run free external tools, parse output, 
 | [specs/INSTALLATION.md](specs/INSTALLATION.md) | 4 install methods, what goes where, uninstall |
 | [specs/GIT-WORKFLOW.md](specs/GIT-WORKFLOW.md) | Branches, commits, PRs, semantic release |
 | [specs/ROADMAP.md](specs/ROADMAP.md) | Feature roadmap, milestones, backlog |
+| [specs/SHANNON-COMPARISON.md](specs/SHANNON-COMPARISON.md) | Shannon comparison, gaps, adoption plan |
 
 ## Git Workflow (MANDATORY)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Executors never attack directly — they run free external tools, parse output, 
 | [specs/GIT-WORKFLOW.md](specs/GIT-WORKFLOW.md) | Branches, commits, PRs, semantic release |
 | [specs/ROADMAP.md](specs/ROADMAP.md) | Feature roadmap, milestones, backlog |
 | [specs/SHANNON-COMPARISON.md](specs/SHANNON-COMPARISON.md) | Shannon comparison, gaps, adoption plan |
+| [specs/SKILL-CRITIQUE-ISSUES.md](specs/SKILL-CRITIQUE-ISSUES.md) | 14 issues from field test, prioritized fix plan |
 
 ## Git Workflow (MANDATORY)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,14 +86,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends golang && \
 
 ENV GOPATH=/opt/go
 ENV PATH="${GOPATH}/bin:${PATH}"
+ENV GONOSUMCHECK=*
+ENV GONOSUMDB=*
 
-RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
-    go install github.com/hahwul/dalfox/v2@latest && \
-    go install github.com/projectdiscovery/katana/cmd/katana@latest && \
-    go install github.com/lc/gau/v2/cmd/gau@latest && \
-    go install github.com/tomnomnom/waybackurls@latest && \
-    go install github.com/s0md3v/smap/cmd/smap@latest && \
-    rm -rf /opt/go/pkg /root/.cache/go-build
+# Install Go tools individually so one failure doesn't block all
+RUN go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest || echo "WARN: subfinder install failed"
+RUN go install github.com/hahwul/dalfox/v2@latest || echo "WARN: dalfox install failed"
+RUN go install github.com/projectdiscovery/katana/cmd/katana@latest || echo "WARN: katana install failed"
+RUN go install github.com/lc/gau/v2/cmd/gau@latest || echo "WARN: gau install failed"
+RUN go install github.com/tomnomnom/waybackurls@latest || echo "WARN: waybackurls install failed"
+RUN go install github.com/s0md3v/smap/cmd/smap@latest || echo "WARN: smap install failed"
+RUN rm -rf /opt/go/pkg /root/.cache/go-build
 
 # ============================================
 # Layer 2b: Python recon tools
@@ -128,9 +131,9 @@ RUN rm -f /usr/local/bin/httpx && ln -sf /usr/bin/httpx-toolkit /usr/local/bin/h
 # ============================================
 # Layer 4: SCA tools (binary installs)
 # ============================================
-RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+RUN curl -sSfL --retry 3 --retry-delay 5 https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin || echo "WARN: grype install failed"
 
-RUN curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+RUN curl -sSfL --retry 3 --retry-delay 5 https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin || echo "WARN: trivy install failed"
 
 # ============================================
 # Layer 5: SSL/TLS + Auth tools
@@ -150,7 +153,7 @@ RUN git clone --depth 1 https://github.com/ticarpi/jwt_tool.git /opt/jwt_tool &&
 RUN go install github.com/zricethezav/gitleaks/v8@latest || \
     (curl -sSfL https://raw.githubusercontent.com/gitleaks/gitleaks/master/scripts/install.sh | sh -s -- -b /usr/local/bin) || true
 
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin || true
+RUN curl -sSfL --retry 3 --retry-delay 5 https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin || true
 
 RUN git clone --depth 1 https://github.com/epinna/tplmap.git /opt/tplmap && \
     ln -s /opt/tplmap/tplmap.py /usr/local/bin/tplmap && \
@@ -165,9 +168,43 @@ RUN CAIDO_URL=$(curl -sSL https://caido.download/releases/latest | python3 -c "i
 # ============================================
 # Layer 6: Playwright (for copilot mode)
 # ============================================
-RUN npm install -g playwright 2>/dev/null && \
-    npx playwright install --with-deps chromium 2>/dev/null || \
-    echo "Playwright install skipped — copilot mode may not work"
+# Install Chromium system dependencies first (Kali/Debian)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libatspi2.0-0 \
+    libwayland-client0 \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Playwright and Chromium browser
+RUN npm install -g playwright && \
+    npx playwright install chromium && \
+    npx playwright install-deps chromium
+
+# Verify Playwright works headless
+RUN node -e "const { chromium } = require('playwright'); \
+    (async () => { \
+      const browser = await chromium.launch({ headless: true }); \
+      const page = await browser.newPage(); \
+      console.log('Playwright OK — Chromium headless works'); \
+      await browser.close(); \
+    })();"
 
 # ============================================
 # Layer 7: Update nuclei templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgbm1 \
     libpango-1.0-0 \
     libcairo2 \
-    libasound2 \
+    libasound2t64 \
     libatspi2.0-0 \
     libwayland-client0 \
     fonts-liberation \

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Playwright and Chromium browser
+ENV NODE_PATH=/usr/lib/node_modules
 RUN npm install -g playwright && \
     npx playwright install chromium && \
     npx playwright install-deps chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,19 +192,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Playwright and Chromium browser
-RUN npm install -g playwright && \
+# Install Playwright locally (not global — avoids NODE_PATH issues)
+WORKDIR /opt/playwright
+RUN npm init -y && \
+    npm install playwright && \
     npx playwright install chromium && \
     npx playwright install-deps chromium
 
 # Verify Playwright works headless
-RUN node -e "const { chromium } = require('playwright'); \
+RUN cd /opt/playwright && node -e "const { chromium } = require('playwright'); \
     (async () => { \
       const browser = await chromium.launch({ headless: true }); \
       const page = await browser.newPage(); \
       console.log('Playwright OK — Chromium headless works'); \
       await browser.close(); \
     })();"
+
+# Set NODE_PATH so playwright can be required from anywhere
+ENV NODE_PATH=/opt/playwright/node_modules
 
 # ============================================
 # Layer 7: Update nuclei templates

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -156,11 +156,11 @@ func shellCmd() *cobra.Command {
 	}
 }
 
-// pentest-kit exec <command...>
+// pentest-kit exec [--no-proxy] <command...>
 func execCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:                "exec [command...]",
-		Short:              "Run a command inside the container",
+		Use:                "exec [--no-proxy] [command...]",
+		Short:              "Run a command inside the container (--no-proxy to skip proxychains)",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -169,6 +169,14 @@ func execCmd() *cobra.Command {
 			ws, err := docker.FindWorkspace()
 			if err != nil {
 				return err
+			}
+			// Handle --no-proxy flag (since DisableFlagParsing is true, parse manually)
+			if args[0] == "--no-proxy" || args[0] == "--direct" {
+				if len(args) < 2 {
+					return fmt.Errorf("usage: pentest-kit exec --no-proxy <command>")
+				}
+				// Set env var so proxychains is skipped inside container
+				return docker.ExecWithEnv(ws, args[1:], []string{"PENTEST_KIT_NO_PROXY=1"})
 			}
 			return docker.Exec(ws, args)
 		},
@@ -274,6 +282,48 @@ func engageCmd() *cobra.Command {
 				name = args[0]
 			}
 			return engage.Status(ws, name)
+		},
+	})
+
+	// pentest-kit engage update <engagement> --phase <phase>
+	var phase string
+	updateCmd := &cobra.Command{
+		Use:   "update <engagement>",
+		Short: "Update engagement phase manually",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := docker.FindWorkspace()
+			if err != nil {
+				return err
+			}
+			if phase == "" {
+				return fmt.Errorf("--phase is required (init, scanning, testing, complete, failed)")
+			}
+			if err := engage.UpdatePhase(ws, args[0], phase); err != nil {
+				return err
+			}
+			fmt.Printf("  ✓ %s phase → %s\n", args[0], phase)
+			return nil
+		},
+	}
+	updateCmd.Flags().StringVar(&phase, "phase", "", "New phase (init, scanning, testing, complete, failed)")
+	cmd.AddCommand(updateCmd)
+
+	// pentest-kit engage reset <engagement>
+	cmd.AddCommand(&cobra.Command{
+		Use:   "reset <engagement>",
+		Short: "Reset engagement — clear failed pipelines, set phase back to init",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := docker.FindWorkspace()
+			if err != nil {
+				return err
+			}
+			if err := engage.Reset(ws, args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("  ✓ %s reset to init phase\n", args[0])
+			return nil
 		},
 	})
 

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -298,7 +298,7 @@ func statusCmd() *cobra.Command {
 // pipelineTools maps pipeline names to the command executed inside the container.
 // Placeholders {target} and {eng} are replaced with actual values at runtime.
 var pipelineTools = map[string][]string{
-	"recon":       {"bash", "-c", "subfinder -d {target} -silent -jsonl -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json && cat /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json | httpx -silent -status-code -title -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/httpx.json"},
+	"recon":       {"bash", "-c", "subfinder -d {target} -silent -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json && cat /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json | jq -r '.host' | httpx -silent -status-code -title -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/httpx.json"},
 	"webapp-scan": {"bash", "-c", "nuclei -u {target} -severity critical,high,medium -jsonl -o /pentest-kit/results/{eng}/scans/vulnerability/nuclei/nuclei-full.json"},
 	"injection":   {"bash", "-c", "sqlmap -u '{target}' --batch --level 1 --risk 1 --output-dir=/pentest-kit/results/{eng}/scans/injection/sqlmap/"},
 	"auth":        {"bash", "-c", "hydra -L /usr/share/seclists/Usernames/top-usernames-shortlist.txt -P /usr/share/seclists/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt {target} http-form-post '/login:user=^USER^&pass=^PASS^:F=incorrect' -o /pentest-kit/results/{eng}/scans/auth/hydra/hydra-results.txt"},

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -347,15 +347,24 @@ func statusCmd() *cobra.Command {
 
 // pipelineTools maps pipeline names to the command executed inside the container.
 // Placeholders {target} and {eng} are replaced with actual values at runtime.
+// Flags verified against container tool versions (Kali rolling, 2026-03).
 var pipelineTools = map[string][]string{
-	"recon":       {"bash", "-c", "subfinder -d {target} -silent -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json && cat /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json | jq -r '.host' | httpx -silent -status-code -title -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/httpx.json"},
+	"recon":       {"bash", "-c", "subfinder -d {target} -silent -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json && jq -r '.host' /pentest-kit/results/{eng}/scans/reconnaissance/raw/subfinder.json 2>/dev/null | sort -u | httpx -silent -status-code -title -json -o /pentest-kit/results/{eng}/scans/reconnaissance/raw/httpx.json"},
 	"webapp-scan": {"bash", "-c", "nuclei -u {target} -severity critical,high,medium -jsonl -o /pentest-kit/results/{eng}/scans/vulnerability/nuclei/nuclei-full.json"},
-	"injection":   {"bash", "-c", "sqlmap -u '{target}' --batch --level 1 --risk 1 --output-dir=/pentest-kit/results/{eng}/scans/injection/sqlmap/"},
-	"auth":        {"bash", "-c", "hydra -L /usr/share/seclists/Usernames/top-usernames-shortlist.txt -P /usr/share/seclists/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt {target} http-form-post '/login:user=^USER^&pass=^PASS^:F=incorrect' -o /pentest-kit/results/{eng}/scans/auth/hydra/hydra-results.txt"},
+	"injection":   {"bash", "-c", "sqlmap -u '{target}' --batch --level 1 --risk 1 --output-dir=/pentest-kit/results/{eng}/scans/injection/sqlmap/ 2>&1 | tee /pentest-kit/results/{eng}/scans/injection/sqlmap/sqlmap.log"},
+	"auth":        {"bash", "-c", "echo 'Auth pipeline requires manual configuration. Use pentest-kit exec to run jwt_tool, hydra, or ffuf with target-specific parameters.' && exit 0"},
 	"sast":        {"bash", "-c", "semgrep --config auto /pentest-kit/targets --json -o /pentest-kit/results/{eng}/scans/sast/semgrep/semgrep-auto.json 2>/dev/null"},
 	"sca":         {"bash", "-c", "trivy fs /pentest-kit/targets --format json -o /pentest-kit/results/{eng}/scans/sca/trivy/trivy-fs.json 2>/dev/null"},
-	"ssl":         {"bash", "-c", "testssl --jsonfile /pentest-kit/results/{eng}/scans/ssl/testssl/testssl.json {target}"},
+	"ssl":         {"bash", "-c", "testssl --jsonfile /pentest-kit/results/{eng}/scans/ssl/testssl/testssl.json --warnings off {target}"},
 	"cve":         {"bash", "-c", "nuclei -u {target} -tags cve -severity critical,high -jsonl -o /pentest-kit/results/{eng}/scans/vulnerability/nuclei/nuclei-cves.json"},
+}
+
+// pipelinesSkipProxy lists pipelines that must NOT go through proxychains.
+// testssl does its own TLS handshake which is incompatible with SOCKS5.
+var pipelinesSkipProxy = map[string]bool{
+	"ssl":  true,
+	"sast": true,
+	"sca":  true,
 }
 
 // validPipelineNames returns a sorted, comma-separated list of available pipelines.
@@ -438,8 +447,15 @@ func scanCmd() *cobra.Command {
 			// Build the command with placeholders replaced
 			execArgs := replacePlaceholders(toolArgs, target, eng)
 
-			fmt.Printf("Running %s pipeline against %s...\n", pipeline, target)
-			execErr := docker.Exec(ws, execArgs)
+			// Some pipelines must skip proxy (testssl, sast, sca)
+			var envVars []string
+			if pipelinesSkipProxy[pipeline] {
+				envVars = []string{"PENTEST_KIT_NO_PROXY=1"}
+				fmt.Printf("Running %s pipeline (no proxy)...\n", pipeline)
+			} else {
+				fmt.Printf("Running %s pipeline against %s...\n", pipeline, target)
+			}
+			execErr := docker.ExecWithEnv(ws, execArgs, envVars)
 
 			if execErr != nil {
 				// Mark pipeline as failed
@@ -467,7 +483,14 @@ func scanCmd() *cobra.Command {
 				}
 			}
 
-			fmt.Printf("Pipeline %s complete. %d findings.\n", pipeline, findingsCount)
+			if findingsCount == 0 {
+				fmt.Printf("  ⚠ Pipeline %s produced 0 results. Possible causes:\n", pipeline)
+				fmt.Println("    - Target unreachable or blocking requests")
+				fmt.Println("    - Proxy interfering (try: pentest-kit exec --no-proxy <cmd>)")
+				fmt.Println("    - Tool flags incompatible (check: pentest-kit exec <tool> -h)")
+			} else {
+				fmt.Printf("Pipeline %s complete. %d findings.\n", pipeline, findingsCount)
+			}
 
 			if err := engage.UpdatePipeline(ws, eng, pipeline, "complete", findingsCount); err != nil {
 				fmt.Printf("  warning: could not update pipeline state: %v\n", err)

--- a/pentest-kit-cli/internal/docker/docker.go
+++ b/pentest-kit-cli/internal/docker/docker.go
@@ -139,11 +139,23 @@ func Down(workspace string) error {
 
 // Exec runs a command inside the container.
 func Exec(workspace string, args []string) error {
+	return ExecWithEnv(workspace, args, nil)
+}
+
+// ExecWithEnv runs a command inside the container with optional extra environment variables.
+func ExecWithEnv(workspace string, args []string, envVars []string) error {
 	if !IsRunning(workspace) {
 		return fmt.Errorf("container not running. Run: pentest-kit up")
 	}
 
-	dockerArgs := append([]string{"compose", "exec", "-T", "pentest-kit"}, args...)
+	// Build docker compose exec command with optional -e flags
+	dockerArgs := []string{"compose", "exec", "-T"}
+	for _, e := range envVars {
+		dockerArgs = append(dockerArgs, "-e", e)
+	}
+	dockerArgs = append(dockerArgs, "pentest-kit")
+	dockerArgs = append(dockerArgs, args...)
+
 	cmd := exec.Command("docker", dockerArgs...)
 	cmd.Dir = workspace
 	cmd.Stdout = os.Stdout

--- a/pentest-kit-cli/internal/engage/engage.go
+++ b/pentest-kit-cli/internal/engage/engage.go
@@ -39,8 +39,8 @@ type FindingsCount struct {
 }
 
 // Init creates a new engagement directory with the full structure.
-// ResultsDir returns the results directory — cwd/results/ if it exists or can be created,
-// otherwise falls back to workspace/results/.
+// ResultsDir returns the results directory — checks cwd/results/ first,
+// then workspace/results/, falls back to cwd/results/ for new engagements.
 func ResultsDir(workspace string) string {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -53,11 +53,10 @@ func ResultsDir(workspace string) string {
 		return cwdResults
 	}
 
-	// If cwd is the workspace, use workspace/results/
-	absWs, _ := filepath.Abs(workspace)
-	absCwd, _ := filepath.Abs(cwd)
-	if absWs == absCwd {
-		return filepath.Join(workspace, "results")
+	// If workspace has a results/ dir, use it (covers report generate from different cwd)
+	wsResults := filepath.Join(workspace, "results")
+	if info, err := os.Stat(wsResults); err == nil && info.IsDir() {
+		return wsResults
 	}
 
 	// Otherwise use cwd/results/ (will be created by Init)
@@ -368,6 +367,22 @@ func UpdateFindings(workspace, engagement string, counts FindingsCount) error {
 		return fmt.Errorf("failed to read state for %q: %w", engagement, err)
 	}
 	state.Findings = counts
+	return writeJSON(statePath, state)
+}
+
+// Reset clears failed/running pipelines and sets phase back to init.
+func Reset(workspace, engagement string) error {
+	statePath := filepath.Join(ResultsDir(workspace), engagement, "state.json")
+	state, err := readState(statePath)
+	if err != nil {
+		return fmt.Errorf("engagement %q not found or missing state.json", engagement)
+	}
+	state.Phase = "init"
+	for name, p := range state.Pipelines {
+		if p.Status == "failed" || p.Status == "running" {
+			state.Pipelines[name] = &Pipeline{Status: "pending"}
+		}
+	}
 	return writeJSON(statePath, state)
 }
 

--- a/pentest-kit-cli/internal/engage/engage.go
+++ b/pentest-kit-cli/internal/engage/engage.go
@@ -193,19 +193,53 @@ func Status(workspace, name string) error {
 
 	fmt.Printf("Engagement: %s\n", state.Engagement)
 	fmt.Printf("Target:     %s\n", state.Target)
-	fmt.Printf("Source:     %s\n", state.Source)
+	if state.Source != "" {
+		fmt.Printf("Source:     %s\n", state.Source)
+	}
 	fmt.Printf("Phase:      %s\n", state.Phase)
 	fmt.Printf("Created:    %s\n", state.Created)
 	fmt.Println()
 
-	// Findings
-	fmt.Printf("Findings: %d Critical, %d High, %d Medium, %d Low, %d Observations\n",
-		state.Findings.Critical, state.Findings.High,
-		state.Findings.Medium, state.Findings.Low,
-		state.Findings.Observations)
+	// Findings summary
+	total := state.Findings.Critical + state.Findings.High + state.Findings.Medium + state.Findings.Low
+	if total > 0 || state.Findings.Observations > 0 {
+		fmt.Printf("Findings:   %d Critical, %d High, %d Medium, %d Low, %d Observations\n",
+			state.Findings.Critical, state.Findings.High,
+			state.Findings.Medium, state.Findings.Low,
+			state.Findings.Observations)
+	} else {
+		fmt.Println("Findings:   none yet")
+	}
 	fmt.Println()
 
-	// Pipelines
+	// Scan coverage summary
+	allPipelines := []string{"recon", "webapp-scan", "injection", "auth", "sast", "sca", "ssl", "cve"}
+	fmt.Print("Scans:      ")
+	for i, p := range allPipelines {
+		if i > 0 {
+			fmt.Print("  ")
+		}
+		if pp, ok := state.Pipelines[p]; ok {
+			switch pp.Status {
+			case "complete":
+				fmt.Printf("%s ✓", p)
+			case "running":
+				fmt.Printf("%s ▶", p)
+			case "failed":
+				fmt.Printf("%s ✗", p)
+			case "skipped":
+				fmt.Printf("%s –", p)
+			default:
+				fmt.Printf("%s ○", p)
+			}
+		} else {
+			fmt.Printf("%s ·", p)
+		}
+	}
+	fmt.Println()
+	fmt.Println()
+
+	// Pipeline details
 	if len(state.Pipelines) > 0 {
 		fmt.Println("Pipelines:")
 		for name, p := range state.Pipelines {
@@ -231,10 +265,19 @@ func Status(workspace, name string) error {
 		}
 	}
 
-	// Reports
+	// Report status
+	fmt.Println()
+	engDir := filepath.Join(ResultsDir(workspace), name)
+	if _, err := os.Stat(filepath.Join(engDir, "reports", "final", "Penetration-Test-Report.md")); err == nil {
+		fmt.Println("Report:     generated")
+	} else if _, err := os.Stat(filepath.Join(engDir, "findings.json")); err == nil {
+		fmt.Println("Report:     not generated (run: pentest-kit report generate " + name + ")")
+	} else {
+		fmt.Println("Report:     no findings.json yet")
+	}
+
+	// Reports list
 	if len(state.Reports) > 0 {
-		fmt.Println()
-		fmt.Println("Reports generated:")
 		for _, r := range state.Reports {
 			fmt.Printf("  - %s\n", r)
 		}

--- a/pentest-kit-cli/internal/engage/engage_test.go
+++ b/pentest-kit-cli/internal/engage/engage_test.go
@@ -386,3 +386,55 @@ func TestReadWriteState(t *testing.T) {
 		t.Errorf("expected 1 critical finding, got %d", loaded.Findings.Critical)
 	}
 }
+
+func TestReset(t *testing.T) {
+	workspace := t.TempDir()
+	chdir(t, workspace)
+
+	// Create engagement with failed state
+	err := Init(workspace, "reset-test", "https://example.com", "")
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	// Set phase to failed and add failed/complete pipelines
+	_ = UpdatePhase(workspace, "reset-test", "failed")
+	_ = UpdatePipeline(workspace, "reset-test", "recon", "complete", 10)
+	_ = UpdatePipeline(workspace, "reset-test", "webapp-scan", "failed", 0)
+	_ = UpdatePipeline(workspace, "reset-test", "injection", "running", 0)
+
+	// Reset
+	err = Reset(workspace, "reset-test")
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+
+	// Verify state
+	statePath := filepath.Join(ResultsDir(workspace), "reset-test", "state.json")
+	data, _ := os.ReadFile(statePath)
+	var state State
+	json.Unmarshal(data, &state)
+
+	if state.Phase != "init" {
+		t.Errorf("expected phase 'init', got %q", state.Phase)
+	}
+	if state.Pipelines["recon"].Status != "complete" {
+		t.Errorf("recon should stay complete, got %q", state.Pipelines["recon"].Status)
+	}
+	if state.Pipelines["webapp-scan"].Status != "pending" {
+		t.Errorf("webapp-scan should be reset to pending, got %q", state.Pipelines["webapp-scan"].Status)
+	}
+	if state.Pipelines["injection"].Status != "pending" {
+		t.Errorf("injection should be reset to pending, got %q", state.Pipelines["injection"].Status)
+	}
+}
+
+func TestReset_NotFound(t *testing.T) {
+	workspace := t.TempDir()
+	chdir(t, workspace)
+
+	err := Reset(workspace, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent engagement")
+	}
+}

--- a/pentest-kit-cli/internal/report/report.go
+++ b/pentest-kit-cli/internal/report/report.go
@@ -567,7 +567,13 @@ func GenerateFromFindings(workspace, engagement string) error {
 
 // Generate combines raw section files into final deliverables (markdown + DOCX + PDF).
 // It does NOT auto-generate sections — the AI agent writes sections using reference/templates/.
-// If no raw sections exist, it tells the user what to do.
+//
+// Required order before calling this:
+//  1. Scans produce tool output in scans/
+//  2. Agent creates scripts/ (PoC scripts)
+//  3. Agent creates findings.json
+//  4. Agent creates reports/raw/ sections using reference/templates/
+//  5. This function combines raw → final + pandoc
 func Generate(workspace, engagement string) error {
 	if engagement == "" {
 		return fmt.Errorf("usage: pentest-kit report generate <engagement>")
@@ -576,6 +582,20 @@ func Generate(workspace, engagement string) error {
 	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	if _, err := os.Stat(base); err != nil {
 		return fmt.Errorf("engagement %q not found at %s", engagement, base)
+	}
+
+	// Check prerequisites
+	findingsPath := filepath.Join(base, "findings.json")
+	if _, err := os.Stat(findingsPath); err != nil {
+		fmt.Println("  ✗ findings.json not found")
+		fmt.Println()
+		fmt.Println("  Before generating the report, the agent must:")
+		fmt.Println("    1. Run scans → scans/")
+		fmt.Println("    2. Create PoC scripts → scripts/")
+		fmt.Println("    3. Create findings.json from confirmed results")
+		fmt.Println("    4. Write report sections using reference/templates/ → reports/raw/")
+		fmt.Println("    5. Then run: pentest-kit report generate <engagement>")
+		return nil
 	}
 
 	rawDir := filepath.Join(base, "reports", "raw")
@@ -587,7 +607,8 @@ func Generate(workspace, engagement string) error {
 	fmt.Println("[1/3] Checking report sections...")
 	rawFiles, err := filepath.Glob(filepath.Join(rawDir, "[0-9][0-9]-*.md"))
 	if err != nil || len(rawFiles) == 0 {
-		fmt.Println("  No raw sections found in reports/raw/")
+		fmt.Println("  ✓ findings.json exists")
+		fmt.Println("  ✗ No raw sections found in reports/raw/")
 		fmt.Println()
 		fmt.Println("  The AI agent writes report sections using reference/templates/.")
 		fmt.Println("  Each section is a numbered markdown file in reports/raw/:")

--- a/pentest-kit-cli/internal/report/report.go
+++ b/pentest-kit-cli/internal/report/report.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/docker"
+	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/engage"
 )
 
 // ---------------------------------------------------------------------------
@@ -506,7 +507,7 @@ func GenerateFromFindings(workspace, engagement string) error {
 		return fmt.Errorf("usage: pentest-kit report generate <engagement>")
 	}
 
-	base := filepath.Join(workspace, "results", engagement)
+	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	if _, err := os.Stat(base); err != nil {
 		return fmt.Errorf("engagement %q not found at %s", engagement, base)
 	}
@@ -572,7 +573,7 @@ func Generate(workspace, engagement string) error {
 		return fmt.Errorf("usage: pentest-kit report generate <engagement>")
 	}
 
-	base := filepath.Join(workspace, "results", engagement)
+	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	if _, err := os.Stat(base); err != nil {
 		return fmt.Errorf("engagement %q not found at %s", engagement, base)
 	}
@@ -670,7 +671,7 @@ func Status(workspace, engagement string) error {
 		return fmt.Errorf("usage: pentest-kit report status <engagement>")
 	}
 
-	base := filepath.Join(workspace, "results", engagement)
+	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	rawDir := filepath.Join(base, "reports", "raw")
 	finalDir := filepath.Join(base, "reports", "final")
 

--- a/pentest-kit-cli/internal/report/report.go
+++ b/pentest-kit-cli/internal/report/report.go
@@ -565,9 +565,9 @@ func GenerateFromFindings(workspace, engagement string) error {
 	return Generate(workspace, engagement)
 }
 
-// Generate produces the final report from raw section files.
-// If no raw sections exist but findings.json is available, it automatically
-// calls GenerateFromFindings to produce them first.
+// Generate combines raw section files into final deliverables (markdown + DOCX + PDF).
+// It does NOT auto-generate sections — the AI agent writes sections using reference/templates/.
+// If no raw sections exist, it tells the user what to do.
 func Generate(workspace, engagement string) error {
 	if engagement == "" {
 		return fmt.Errorf("usage: pentest-kit report generate <engagement>")
@@ -576,11 +576,6 @@ func Generate(workspace, engagement string) error {
 	base := filepath.Join(engage.ResultsDir(workspace), engagement)
 	if _, err := os.Stat(base); err != nil {
 		return fmt.Errorf("engagement %q not found at %s", engagement, base)
-	}
-
-	findingsPath := filepath.Join(base, "findings.json")
-	if _, err := os.Stat(findingsPath); err != nil {
-		return fmt.Errorf("findings.json not found — run scans first")
 	}
 
 	rawDir := filepath.Join(base, "reports", "raw")
@@ -592,13 +587,13 @@ func Generate(workspace, engagement string) error {
 	fmt.Println("[1/3] Checking report sections...")
 	rawFiles, err := filepath.Glob(filepath.Join(rawDir, "[0-9][0-9]-*.md"))
 	if err != nil || len(rawFiles) == 0 {
-		// No raw sections — try to generate from findings.json
-		fmt.Println("  No raw sections found, generating from findings.json...")
-		if genErr := GenerateFromFindings(workspace, engagement); genErr != nil {
-			return genErr
-		}
-		// After generation, GenerateFromFindings calls Generate recursively,
-		// so we return here to avoid double-processing.
+		fmt.Println("  No raw sections found in reports/raw/")
+		fmt.Println()
+		fmt.Println("  The AI agent writes report sections using reference/templates/.")
+		fmt.Println("  Each section is a numbered markdown file in reports/raw/:")
+		fmt.Println("    00-README.md, 01-COVER-AND-SCOPE.md, 02-EXECUTIVE-SUMMARY.md, ...")
+		fmt.Println()
+		fmt.Println("  Once sections exist, run this command again to combine + export DOCX.")
 		return nil
 	}
 

--- a/pentest-kit-cli/internal/report/report_test.go
+++ b/pentest-kit-cli/internal/report/report_test.go
@@ -185,14 +185,20 @@ func TestStatus_WithSections(t *testing.T) {
 	}
 }
 
-func TestGenerate_NoFindingsJSON(t *testing.T) {
+func TestGenerate_NoRawSections(t *testing.T) {
 	workspace := t.TempDir()
 	engDir := filepath.Join(workspace, "results", "test-eng")
 	os.MkdirAll(engDir, 0755)
 
+	// Generate with no raw sections should succeed but not produce final report
 	err := Generate(workspace, "test-eng")
-	if err == nil {
-		t.Fatal("expected error when findings.json missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Final report should NOT exist since there are no raw sections
+	finalPath := filepath.Join(engDir, "reports", "final", "Penetration-Test-Report.md")
+	if _, err := os.Stat(finalPath); err == nil {
+		t.Fatal("final report should not exist when no raw sections")
 	}
 }
 
@@ -468,9 +474,10 @@ func TestGenerateFromFindings_NoState(t *testing.T) {
 	}
 }
 
-func TestGenerate_AutoFallbackToFindings(t *testing.T) {
-	// When no raw sections exist but findings.json does, Generate should
-	// automatically call GenerateFromFindings.
+func TestGenerate_NoAutoFallback(t *testing.T) {
+	// Generate should NOT auto-generate sections. Agent writes them.
+	// When reports/raw/ is empty, Generate should return nil (no error)
+	// and NOT create any section files.
 	workspace := t.TempDir()
 	engDir := filepath.Join(workspace, "results", "test-eng")
 	os.MkdirAll(engDir, 0755)
@@ -479,22 +486,17 @@ func TestGenerate_AutoFallbackToFindings(t *testing.T) {
 	writeFindingsJSON(t, engDir, ff)
 	writeStateJSON(t, engDir)
 
-	// Call Generate directly (not GenerateFromFindings)
-	_ = Generate(workspace, "test-eng")
-
-	rawDir := filepath.Join(engDir, "reports", "raw")
-	expectedFiles := []string{
-		"00-README.md",
-		"01-COVER-AND-SCOPE.md",
-		"02-EXECUTIVE-SUMMARY.md",
-		"03-FINDINGS.md",
-		"04-REMEDIATION.md",
-		"05-EVIDENCE-LOG.md",
+	// Call Generate — should not auto-generate sections
+	err := Generate(workspace, "test-eng")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, name := range expectedFiles {
-		if _, err := os.Stat(filepath.Join(rawDir, name)); err != nil {
-			t.Errorf("Generate auto-fallback should have created %s", name)
-		}
+
+	// raw/ should be empty (no auto-generated sections)
+	rawDir := filepath.Join(engDir, "reports", "raw")
+	files, _ := filepath.Glob(filepath.Join(rawDir, "[0-9][0-9]-*.md"))
+	if len(files) > 0 {
+		t.Errorf("Generate should NOT auto-create sections, but found %d files", len(files))
 	}
 }
 

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -59,7 +59,7 @@ User invokes /pentest-kit
 |------|---------|-------------|
 | **Auto** | `/pentest-kit` | Fully automated — run pipelines, tools, generate report |
 | **Assist** | `/pentest-kit assist` | User tests in Caido → agent processes exports with tools |
-| **Copilot** | `/pentest-kit copilot` | Agent drives Playwright + mitmproxy, user directs actions |
+| **Copilot** | `/pentest-kit copilot` | Agent drives Playwright (headless in container) + mitmproxy, user directs actions |
 
 ## Key Design Decisions
 

--- a/specs/DOCKER.md
+++ b/specs/DOCKER.md
@@ -73,7 +73,7 @@ Layer 5: SSL/auth (testssl, jwt_tool)
        : Secrets (gitleaks via go install, trufflehog)
        : SSTI (tplmap)
        : Caido CLI
-Layer 6: Node.js + Playwright + Chromium
+Layer 6: Chromium system deps (libnss3, libgbm1, etc.) + Playwright + headless verify
 Layer 7: nuclei template update
 Layer 8: pentest-kit files (.claude/, tools/, docs)
        : workspace dirs (targets/, results/ with 777)

--- a/specs/PROXY.md
+++ b/specs/PROXY.md
@@ -54,6 +54,29 @@ Proxy activation is **mandatory** before any network scanning. The startup seque
 pentest-kit init → pentest-kit proxy tor → pentest-kit proxy status → scan
 ```
 
+## Tool Proxy Compatibility
+
+Not all tools work through proxychains/Tor. The CLI auto-skips proxy for incompatible pipelines.
+
+| Tool | Via proxychains | Via native proxy flag | Notes |
+|------|----------------|----------------------|-------|
+| nmap | Partial (TCP only) | N/A | Raw sockets don't proxy. TCP connect scan works |
+| nuclei | Yes | `-proxy socks5://127.0.0.1:9050` | Native flag preferred |
+| sqlmap | Yes | `--proxy socks5://127.0.0.1:9050` | Works well |
+| dalfox | Yes | `--proxy socks5://127.0.0.1:9050` | Works well |
+| ffuf | Slow | `-x socks5://127.0.0.1:9050` | Very slow through Tor |
+| subfinder | Yes | N/A | DNS-based, works |
+| httpx | Partial | N/A | May fail with `-cdn` flag |
+| testssl.sh | **No** | N/A | Does own TLS handshake — incompatible with SOCKS5 |
+| katana | **Poor** | N/A | Often returns 0 results through Tor |
+| gau | **Poor** | N/A | API-based, Tor exit nodes often blocked |
+| semgrep | N/A | N/A | Local analysis, no network |
+| trivy | N/A | N/A | Local analysis, no network |
+| bandit | N/A | N/A | Local analysis, no network |
+
+The `ssl`, `sast`, and `sca` pipelines auto-skip proxy via `pipelinesSkipProxy` in the CLI.
+Use `pentest-kit exec --no-proxy <cmd>` for tools that fail through proxy.
+
 ## Copilot Mode
 
 In copilot mode, mitmproxy serves as both interceptor and proxy:

--- a/specs/REPORTS.md
+++ b/specs/REPORTS.md
@@ -66,16 +66,27 @@ reports/
 - Difficulty rating — Low/Medium/High alongside CVSS
 - Vulnerabilities vs Observations — exploitable bugs separated from hardening advice
 
-## Go CLI Report Generator
+## Report Generation Flow
 
-The Go CLI (`pentest-kit-cli/internal/report/report.go`) implements `GenerateFromFindings()` which:
+Two-step process — agent writes sections, CLI combines them:
 
-1. Reads `findings.json` and `state.json`
-2. Generates 6 core sections (README, Cover, Executive Summary, Findings, Remediation, Evidence Log)
-3. Combines into `reports/final/Penetration-Test-Report.md`
-4. Runs pandoc inside the container for DOCX/PDF output
+**Step 1 (AI Agent):** Read templates from `reference/templates/`, fill with engagement data and findings, write numbered sections to `reports/raw/`:
+```
+reference/templates/COVER-AND-SCOPE.md → reports/raw/01-COVER-AND-SCOPE.md
+reference/templates/EXECUTIVE-SUMMARY.md → reports/raw/02-EXECUTIVE-SUMMARY.md
+reference/templates/FINDINGS.md → reports/raw/03-FINDINGS.md
+...
+```
 
-Usage: `pentest-kit report generate <engagement>`
+**Step 2 (CLI):** Combine raw sections into final deliverables:
+```bash
+pentest-kit report generate <engagement>
+# → combines reports/raw/*.md → reports/final/Penetration-Test-Report.md
+# → pandoc → .docx + .pdf
+```
+
+The CLI does NOT auto-generate report content. It only combines and exports what the agent wrote.
+If `reports/raw/` is empty, it tells the agent to write sections using templates first.
 
 ## Rendering Spec
 

--- a/specs/SHANNON-COMPARISON.md
+++ b/specs/SHANNON-COMPARISON.md
@@ -1,0 +1,291 @@
+# Shannon Comparison & Adoption Plan
+
+> Comparison between pentest-kit and [Shannon](https://github.com/KeygraphHQ/shannon) (KeygraphHQ).
+> Shannon is an autonomous white-box AI pentester. pentest-kit is a tool-orchestrated framework.
+> Different philosophies — but Shannon has capabilities worth adopting.
+
+---
+
+## Architecture Comparison
+
+| Aspect | Shannon | pentest-kit |
+|--------|---------|-------------|
+| **Approach** | LLM-driven autonomous pentester | Tool orchestration via agents |
+| **Language** | TypeScript (Node.js) | Go CLI + Python wrappers + Claude Code agents |
+| **Scanning** | LLM reasons about code + browser exploitation | 38 external tools (nmap, nuclei, sqlmap, etc.) |
+| **SAST** | Code Property Graph (CPG) with reachability | semgrep + bandit (pattern matching) |
+| **DAST** | Browser automation + CLI exploits | Tool pipelines (nuclei, dalfox, sqlmap, etc.) |
+| **Container** | Docker (Node.js + Playwright + tools) | Docker (Kali + 38 tools + Playwright) |
+| **Auth handling** | Auto 2FA/TOTP/SSO login flows | Manual (Caido session setup or Playwright) |
+| **Report** | Auto-generated, proven-only findings | 16 templates, Shannon quality bar, Go CLI generator |
+| **Modes** | Auto only | Auto + Assist (Caido) + Copilot (Playwright) |
+
+## What Shannon Has That We Don't
+
+### 1. Code Property Graph (CPG) — Critical Gap
+
+Shannon transforms source code into a combined AST + control flow + program dependence graph.
+This enables:
+- **Reachability analysis** — "is this tainted input actually reachable from a user endpoint?"
+- **Data flow tracking** — trace user input through sanitization to sink
+- **Context-aware analysis** — LLM reasons about each node, not just pattern matching
+
+**Why it matters:** semgrep finds patterns but can't tell if a vulnerability is reachable. CPG can.
+
+### 2. Static-Dynamic Correlation — Critical Gap
+
+Shannon links static findings to dynamic exploits:
+```
+Source code vuln → Live exploitation → Maps back to exact code line + commit
+```
+
+pentest-kit runs SAST and DAST separately — no cross-reference between them.
+A semgrep finding and a nuclei finding for the same vuln appear as two separate items.
+
+### 3. LLM-Driven Analysis — Significant Gap
+
+Shannon uses LLMs to:
+- Reason about sanitization effectiveness at each data flow node
+- Discover business logic invariants
+- Generate custom fuzzers for domain-specific logic
+- Decide exploitation strategy based on code context
+
+pentest-kit uses LLMs only for coordination (orchestrator/executor agents), not for analysis.
+
+### 4. Auto Authentication (2FA/TOTP/SSO) — Gap
+
+Shannon handles complex auth flows autonomously:
+- Form-based login
+- TOTP code generation from secret
+- SSO redirect chains
+- Session persistence across test phases
+
+pentest-kit requires manual session setup via Caido or hardcoded tokens.
+
+### 5. WSTG Checklist Mapping — Gap
+
+Shannon maps every finding to OWASP Web Security Testing Guide (WSTG) IDs.
+55+ WSTG items covered with explicit pass/fail tracking.
+
+pentest-kit has no WSTG mapping — findings reference CWE and OWASP Top 10 but not WSTG test IDs.
+
+### 6. Resume/Checkpoint System — Gap
+
+Shannon checkpoints progress via git commits per agent phase.
+Interrupted runs can resume without re-running completed work.
+
+pentest-kit has `state.json` with pipeline status tracking but `engage resume` is not implemented.
+
+### 7. Business Logic Testing — Gap
+
+Shannon discovers application-specific invariants and auto-generates fuzzers.
+Example: "this coupon code should only be usable once" → generates concurrent redemption test.
+
+pentest-kit has no automated business logic testing — relies on manual Caido testing.
+
+## What We Have That Shannon Doesn't
+
+### Tool Coverage (38 vs 4)
+
+| Category | pentest-kit | Shannon |
+|----------|------------|---------|
+| Recon | subfinder, dnsx, httpx, nmap, katana, gau, waybackurls | subfinder, nmap, whatweb |
+| Discovery | ffuf, feroxbuster, gobuster, arjun, paramspider | None (LLM-driven) |
+| Scanning | nuclei, ZAP, nikto, wapiti | Schemathesis (API only) |
+| Injection | sqlmap, dalfox, commix, tplmap | LLM + browser |
+| Auth | jwt_tool, hydra | LLM + browser |
+| SAST | semgrep, bandit | CPG engine |
+| SCA | trivy, grype, gitleaks, trufflehog | **None** |
+| SSL | testssl.sh | Basic TLS check |
+| Proxy | Caido, mitmproxy, proxychains, tor | None |
+| Reporting | pandoc (DOCX/PDF) | Auto-generated |
+
+### SCA Pipeline
+
+Shannon has **no SCA** — no dependency scanning, no container scanning, no secret detection.
+Their COVERAGE.md says: "Shannon does not report on vulnerable third-party libraries."
+We have trivy + grype + gitleaks + trufflehog covering deps, containers, IaC, and secrets.
+
+### Infrastructure Scanning
+
+Shannon is web-app focused only. We cover:
+- Full port scanning (nmap)
+- DNS enumeration (dnsx)
+- SSL/TLS deep analysis (testssl.sh)
+- SMB, VLAN, network infrastructure
+
+### Three Modes
+
+Shannon is auto-only. We support:
+- **Auto** — fully automated pipelines
+- **Assist** — user tests in Caido, agent processes exports
+- **Copilot** — agent drives Playwright + mitmproxy, user directs
+
+### Custom Rules
+
+We have shared rules (`rules/`) and project-specific rules (`{cwd}/rules/` → `rules.local/`).
+Shannon has no user-configurable rule system.
+
+### Attack Documentation
+
+151 attack methodology docs with quickstarts, cheat sheets, and PortSwigger lab walkthroughs.
+Shannon has prompt files but no user-facing methodology docs.
+
+---
+
+## Adoption Plan
+
+What we should adopt from Shannon, prioritized by impact.
+
+### P0 — Immediate (next milestone)
+
+#### 1. WSTG Checklist Mapping
+
+Add `wstg_id` field to findings.json schema:
+```json
+{
+  "id": "FIND-001",
+  "wstg_id": "WSTG-INPV-05",
+  "title": "SQL Injection in login endpoint",
+  ...
+}
+```
+
+Create `specs/WSTG-COVERAGE.md` tracking which WSTG items our tools cover.
+Map each tool's output to WSTG IDs so coverage is measurable.
+
+#### 2. Connectivity Pre-Check
+
+Add to startup sequence before scanning:
+```bash
+pentest-kit preflight --target <url>    # verify target responds
+```
+
+Check: HTTP response, DNS resolution, port open.
+Fail fast instead of running 10 minutes of scans against a dead target.
+
+#### 3. Resume/Checkpoint (`engage resume`)
+
+Implement `pentest-kit engage resume <engagement>`:
+- Read `state.json` for pipeline status
+- Skip pipelines marked `complete`
+- Re-run pipelines marked `failed` or `running`
+- Continue from current phase
+
+### P1 — Next Version
+
+#### 4. Static-Dynamic Correlation
+
+Link SAST findings to DAST findings:
+```json
+{
+  "id": "FIND-003",
+  "static_finding": "semgrep:sqli-patterns:app/db.py:42",
+  "dynamic_finding": "sqlmap:/api/users?id=1",
+  "correlation": "confirmed"
+}
+```
+
+When semgrep finds a potential SQLi and sqlmap confirms it at the same endpoint,
+merge them into one finding with both code location and exploitation proof.
+
+Implementation:
+- After SAST pipeline, extract file:line + vuln type
+- After DAST pipeline, extract endpoint + vuln type
+- Correlator matches on endpoint ↔ code route mapping
+- Correlated findings get higher confidence score
+
+#### 5. Auto-Auth Flow
+
+Add authentication configuration to engagement init:
+```yaml
+# auth-config.yaml
+type: form
+login_url: https://app.com/login
+username_field: email
+password_field: password
+credentials:
+  - email: test@example.com
+    password: testpass123
+totp_secret: JBSWY3DPEHPK3PXP    # optional
+success_indicator: dashboard
+```
+
+CLI reads config, Playwright logs in, captures session, passes to tools.
+Eliminates manual Caido session setup for standard auth flows.
+
+#### 6. Observations vs Findings in Main Skill Doc
+
+The skill user feedback said this split is "buried in templates."
+Add to SKILL.md main section:
+- **Vulnerability** = exploitable, tool-confirmed, has PoC
+- **Observation** = hardening advice, not exploitable, no PoC
+
+### P2 — Future
+
+#### 7. LLM-Augmented SAST
+
+Don't build a CPG — that's Shannon's core product and massive engineering effort.
+Instead, use LLM to enhance semgrep findings:
+
+```
+semgrep finds potential SQLi at app/db.py:42
+  → LLM reads the function + surrounding context
+  → LLM determines: "input is sanitized by ORM parameterization at line 38"
+  → Finding downgraded to observation (false positive eliminated)
+```
+
+This gives us 80% of CPG's value with 10% of the effort.
+
+#### 8. Business Logic Fuzzer
+
+Use LLM to analyze source code and generate business logic test cases:
+```
+LLM reads checkout flow code
+  → Identifies invariant: "discount code should only apply once"
+  → Generates test: send concurrent checkout requests with same discount
+  → Executes via Playwright
+  → Reports: "Race condition allows double-discount"
+```
+
+Requires source code access (`--source`) and Playwright (copilot mode).
+
+#### 9. API Schema-Based Fuzzing
+
+Shannon uses Schemathesis for schema-based API fuzzing.
+We should add it to our tool stack:
+```bash
+# Add to Dockerfile
+pip install schemathesis
+
+# Add to REGISTRY.md
+schemathesis:
+  template: "st run {openapi_url} --checks all --report {output_file}"
+```
+
+Fuzzes all API endpoints based on OpenAPI/Swagger spec automatically.
+
+---
+
+## What NOT to Adopt
+
+| Shannon Feature | Why Skip |
+|----------------|----------|
+| CPG engine | Massive engineering effort, Shannon's core IP. Use LLM-augmented SAST instead |
+| TypeScript rewrite | Our Go CLI + Python wrappers + Claude agents work well |
+| Dropping tool diversity | Shannon uses 4 tools + LLM. Our 38 tools give broader coverage |
+| Auto-only mode | Our 3 modes (auto/assist/copilot) are a strength |
+| Dropping SCA | Shannon explicitly doesn't do SCA. We should keep it |
+
+---
+
+## Summary
+
+Shannon is strong where we're weak (code analysis, static-dynamic correlation, auth automation).
+We're strong where Shannon is weak (tool coverage, SCA, infrastructure, manual testing modes).
+
+The ideal pentest-kit v1.0 combines both:
+- Our tool-orchestrated breadth + Shannon-inspired code-aware depth
+- 38 tools for coverage + LLM for context-aware analysis
+- WSTG-mapped findings with static-dynamic correlation
+- Auto-auth for standard flows + Caido for complex manual testing

--- a/specs/SKILL-CRITIQUE-ISSUES.md
+++ b/specs/SKILL-CRITIQUE-ISSUES.md
@@ -1,0 +1,317 @@
+# Skill Critique Issues
+
+> Issues discovered during real-world skill usage (pentest engagement via `/pentest-kit`).
+> Each issue is categorized, prioritized, and has an implementation plan.
+> Reference: field test against live targets using the auto-mode workflow.
+
+---
+
+## Scorecard (Current State)
+
+| Area | Score | Target |
+|------|-------|--------|
+| Skill documentation | 8/10 | 9/10 |
+| CLI core (init, proxy, exec) | 7/10 | 9/10 |
+| CLI pipelines (scan) | 2/10 | 8/10 |
+| CLI reports (report generate) | 2/10 | 8/10 |
+| Tool compatibility | 5/10 | 8/10 |
+| Report templates | 9/10 | 9/10 |
+| Error handling/recovery | 3/10 | 7/10 |
+| End-to-end workflow | 4/10 | 8/10 |
+
+---
+
+## P0 — Broken (Must Fix)
+
+### Issue 1: Scan pipelines don't work
+
+**Problem:** `pentest-kit scan recon` fails with `flag provided but not defined: -jsonl`.
+All pipelines in `pipelineTools` map have flag errors or incompatibilities.
+
+**Status:** Partially fixed — subfinder `-jsonl` → `-json` in PR #31.
+Remaining: need to audit ALL pipeline commands against actual container tool versions.
+
+**Fix:**
+1. Start container, run each pipeline command manually inside it
+2. Fix every flag that doesn't match the installed tool version
+3. Add integration test: `pentest-kit scan <pipeline> --target <test-target>` for each pipeline
+4. Add `--dry-run` flag that prints the command without executing
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go` (pipelineTools map)
+
+---
+
+### Issue 2: `report generate` can't find engagements
+
+**Problem:** CLI looks in `~/.pentest-kit/results/` but engagement was created in `{cwd}/results/`.
+The `ResultsDir()` function in engage.go returns cwd-based path for `init` but `report generate`
+uses workspace-based path.
+
+**Root cause:** `report.go` line 509: `filepath.Join(workspace, "results", engagement)` —
+hardcodes workspace path instead of using `engage.ResultsDir(workspace)`.
+
+**Fix:**
+```go
+// report.go — Generate and GenerateFromFindings
+// Change:
+base := filepath.Join(workspace, "results", engagement)
+// To:
+base := filepath.Join(engage.ResultsDir(workspace), engagement)
+```
+
+**Files:** `pentest-kit-cli/internal/report/report.go`
+
+---
+
+### Issue 3: state.json stuck on "failed" with no recovery
+
+**Problem:** When `scan recon` fails, state.json phase = "failed". Manual scans succeed but
+state isn't updated. No way to reset or update phase.
+
+**Fix:**
+1. Add `pentest-kit engage update <engagement> --phase <phase>` command
+2. Add `pentest-kit engage reset <engagement>` — sets phase back to "init", clears failed pipelines
+3. Make `pentest-kit scan` update state even when run manually after a failure
+4. Auto-detect scan output files and update pipeline status accordingly
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go`, `pentest-kit-cli/internal/engage/engage.go`
+
+---
+
+## P1 — Tool Compatibility
+
+### Issue 4: httpx flags wrong
+
+**Problem:** Container has httpx v1.1.5 (httpx-toolkit). Pipeline/docs pass `-u` flag but
+this version uses stdin or `-l` for input. Also `-cdn` causes DNS crash.
+
+**Fix:**
+1. Audit httpx flags in container: `pentest-kit exec httpx -h`
+2. Update REGISTRY.md httpx commands
+3. Update recon pipeline to pipe input via stdin (already fixed in PR #31 with `jq | httpx`)
+4. Remove `-cdn` from any pipeline/doc commands
+5. Add httpx version note to TOOLS.md quirks section
+
+**Files:** `tools/REGISTRY.md`, `specs/TOOLS.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 5: testssl.sh fails through proxychains
+
+**Problem:** SSL handshake can't go through SOCKS5 proxy. testssl always fails via proxychains.
+
+**Fix:**
+1. Document limitation in `specs/PROXY.md`: "testssl must run without proxy"
+2. Update ssl pipeline to skip proxychains automatically:
+   ```go
+   "ssl": {"bash", "-c", "testssl --jsonfile ... {target}"}  // no proxychains prefix
+   ```
+3. Add `proxy_compatible: false` field to tool registry for tools that can't use proxy
+4. `pentest-kit scan ssl` should auto-skip proxy even when enabled
+
+**Files:** `specs/PROXY.md`, `specs/TOOLS.md`, `tools/REGISTRY.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 6: No `--no-proxy` flag for `pentest-kit exec`
+
+**Problem:** Once proxy is enabled, ALL exec commands go through proxychains.
+Some tools (httpx, testssl, nuclei) work poorly through Tor.
+
+**Fix:**
+Add `--no-proxy` / `--direct` flag to exec:
+```go
+// pentest-kit exec --no-proxy testssl https://target.com
+// Runs command without proxychains prefix
+```
+
+Also add per-pipeline proxy config:
+```go
+pipelineTools["ssl"].ProxyRequired = false
+```
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go`, `pentest-kit-cli/internal/docker/docker.go`
+
+---
+
+### Issue 7: katana and gau produce empty output through Tor
+
+**Problem:** URL discovery tools return 0 results through proxychains/Tor.
+Tools silently fail — no error, just empty files.
+
+**Fix:**
+1. Pipeline orchestration should check output file size after each step
+2. If output is empty, warn and optionally retry without proxy
+3. Add `--retry-without-proxy` behavior for discovery tools
+4. Document in PROXY.md which tools degrade through Tor
+
+**Files:** `specs/PROXY.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+## P2 — Skill Document Issues
+
+### Issue 8: Auto-mode workflow is aspirational
+
+**Problem:** The documented workflow `Init → Proxy → Recon → Plan → Test → Aggregate → Report`
+doesn't work end-to-end. scan fails, report generate fails, findings.json doesn't exist.
+
+**Fix:**
+1. Fix P0 issues first (pipelines, report path, state recovery)
+2. Then update SKILL.md workflow to reflect what actually works
+3. Add a "Manual Fallback" section: if scan pipeline fails, here's how to run tools directly
+4. Add end-to-end integration test that runs the full workflow
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`
+
+---
+
+### Issue 9: Executor agents section is confusing
+
+**Problem:** Skill recommends deploying executor subagents but then says "if that doesn't work,
+run from orchestrator directly." In practice, orchestrator-direct is the only reliable path.
+
+**Fix:** Update SKILL.md to be opinionated:
+- **Primary pattern:** orchestrator runs `pentest-kit exec` directly
+- **Optional:** deploy parallel executor subagents for independent pipelines
+- Remove the hedging language
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`, `.claude/agents/orchestrator.md`
+
+---
+
+### Issue 10: Missing "what to do when tools fail" guidance
+
+**Problem:** Error handling section is thin. Real failures are flag incompatibilities,
+proxy issues, and DNS resolution — preflight doesn't catch these.
+
+**Fix:** Add troubleshooting section to SKILL.md:
+```markdown
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `flag provided but not defined` | Tool version mismatch | Check `pentest-kit exec <tool> -h` |
+| Empty output file | Proxy blocking tool | Retry with `--no-proxy` |
+| `DNS lookup failed` | Tor DNS resolution | Use `-cdn false` or direct connection |
+| `connection refused` | Target down | Run `pentest-kit preflight --target <url>` |
+| state.json stuck on "failed" | Pipeline crashed | `pentest-kit engage reset <eng>` |
+```
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`
+
+---
+
+## P3 — CLI Enhancements
+
+### Issue 11: Add `pentest-kit exec --save <label>`
+
+**Problem:** Output paths are long and error-prone.
+`pentest-kit exec nmap ... -oX /pentest-kit/results/{eng}/scans/reconnaissance/raw/nmap.xml`
+
+**Fix:** Add `--save` shorthand:
+```bash
+pentest-kit exec --save recon/nmap nmap -sV target.com -oX {auto}
+# auto-resolves to /pentest-kit/results/{latest-eng}/scans/reconnaissance/raw/nmap.xml
+```
+
+**Files:** `pentest-kit-cli/cmd/pentest-kit/main.go`, `pentest-kit-cli/internal/docker/docker.go`
+
+---
+
+### Issue 12: findings.json should be built incrementally
+
+**Problem:** findings.json must be manually written at the end. No way to add findings one at a time.
+
+**Fix:** Add CLI commands:
+```bash
+pentest-kit finding add \
+  --id FIND-001 \
+  --severity HIGH \
+  --title "SQL Injection in login" \
+  --endpoint "/api/auth" \
+  --tool sqlmap \
+  --poc "sqlmap -u 'https://target/api/auth?user=1' --batch"
+
+pentest-kit finding list          # show all findings
+pentest-kit finding export        # write findings.json
+```
+
+**Files:** New `pentest-kit-cli/internal/finding/finding.go`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 13: Report section auto-generation from findings.json
+
+**Problem:** `report generate` exists and works from findings.json, but the user didn't know.
+The skill doc doesn't make the `report generate` → template flow explicit.
+
+**Fix:**
+1. Fix the path resolution bug (Issue 2) so `report generate` actually works
+2. Make SKILL.md auto-mode workflow explicitly say: "run `pentest-kit report generate <eng>`"
+3. Add `pentest-kit report preview <eng>` that shows which sections would be generated
+
+**Files:** `.claude/skills/pentest-kit/SKILL.md`, `pentest-kit-cli/cmd/pentest-kit/main.go`
+
+---
+
+### Issue 14: Better `pentest-kit engage status` output
+
+**Problem:** Status output is basic. Should show scan coverage and finding counts.
+
+**Fix:** Enhance status output:
+```
+Engagement: beleka-tekadesa
+Target:     https://desa.beleka.tekadesa.com
+Phase:      testing
+
+Scans:  recon ✓  vuln ✓  injection ✓  ssl ✗  sast N/A  sca N/A
+Findings: 1 HIGH, 3 MEDIUM, 4 LOW, 3 OBS
+Report: not generated
+
+Pipelines:
+  ✓ recon: complete (12 findings)
+  ✓ webapp-scan: complete (5 findings)
+  ✗ ssl: failed (testssl proxy incompatible)
+  – sast: skipped (no --source)
+```
+
+**Files:** `pentest-kit-cli/internal/engage/engage.go`
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (Fix broken things):
+  Issue 2  → report path resolution (quick fix, 1 line)
+  Issue 3  → engage update/reset commands
+  Issue 1  → audit all pipeline flags in container
+
+Phase 2 (Tool compat):
+  Issue 5  → testssl proxy skip
+  Issue 6  → --no-proxy flag
+  Issue 4  → httpx flag audit
+  Issue 7  → empty output detection
+
+Phase 3 (Skill doc):
+  Issue 8  → update auto-mode workflow
+  Issue 9  → simplify executor section
+  Issue 10 → add troubleshooting table
+
+Phase 4 (Enhancements):
+  Issue 12 → incremental findings
+  Issue 14 → better engage status
+  Issue 11 → exec --save shorthand
+  Issue 13 → report preview
+```
+
+---
+
+## Cross-References
+
+- Pipeline flag fixes → `tools/REGISTRY.md` (source of truth for tool commands)
+- Proxy compatibility → `specs/PROXY.md`
+- Tool quirks → `specs/TOOLS.md`
+- Shannon adoption → `specs/SHANNON-COMPARISON.md` (P0: connectivity pre-check, resume)
+- Report system → `specs/REPORTS.md`

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -32,7 +32,7 @@ all_sources:
   parse: "sort -u"
 
 json:
-  template: "subfinder -d {domain} -all -silent -jsonl -o {output_file}"
+  template: "subfinder -d {domain} -all -silent -json -o {output_file}"
   output: "json"
   parse: "jq -r '.host' {output_file} | sort -u"
 ```


### PR DESCRIPTION
## Summary
Major release consolidating all dev work since v0.11.3:

- **Go CLI (13 commands):** init, up, down, shell, exec, preflight, scan, report, engage, status, logs, proxy — with `--no-proxy`, `engage reset/update`, findings.json validation
- **Docker:** Playwright + Chromium installed locally in /opt/playwright, proper system deps, resilient Go tool installs
- **Specs (16 files):** Architecture, CLI, Docker, Tools, Agents, Engagement, Findings, Reports, Attacks, Proxy, Installation, Git Workflow, Roadmap, Shannon Comparison, Skill Critique Issues, Directory Map
- **Report flow:** 5-step validation (scans → scripts → findings → raw → final), pandoc DOCX+PDF
- **Pipeline fixes:** subfinder -json, httpx jq pipe, ssl/sast/sca auto-skip proxy, empty output detection
- **Agent fixes:** Orchestrator/executor use correct subagent_type, orchestrator-direct as primary pattern
- **Reference fixes:** ATTACK_INDEX paths, CAIDO_INTEGRATION paths, RECONNAISSANCE_OUTPUT paths
- **CI/CD:** Docker builds on dev push, build-cli workflow, smart rebuild detection

### PRs included
- #29 specs polish + rules.local
- #31 subfinder flag fix
- #32 Shannon comparison
- #33 skill critique issues
- #34 P0 report path + state recovery
- #35 remaining critique fixes
- #36 libasound2 package name
- #37 Dockerfile NODE_PATH
- #38 Dockerfile playwright local install
- #39 report flow validation
- #40 auto-mode workflow + copilot status

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (docker, engage, report packages)
- [ ] Docker image builds in CI
- [ ] `pentest-kit init` + `pentest-kit preflight` work
- [ ] `pentest-kit report generate` validates prerequisites correctly