### PR TITLE
fix(proxy): start tor as real daemon, verify SOCKS5 round-trip #42

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -33,13 +33,14 @@ All tools run inside a hardened Docker container. Use the `pentest-kit` CLI:
 pentest-kit init <engagement> --target <url> [--source <path>]
 pentest-kit up / down / shell / status
 
-# Proxy (MANDATORY before any network scanning)
-pentest-kit proxy tor                    # route through Tor
-pentest-kit proxy socks5 <host:port>     # route through SOCKS5
-pentest-kit proxy http <host:port>       # route through HTTP proxy
+# Proxy (choose one per engagement — see "Proxy Selection" below)
+pentest-kit proxy off                    # direct — authorized pentest with IP whitelist
+pentest-kit proxy socks5 <host:port>     # VPS or residential SOCKS5
+pentest-kit proxy http <host:port>       # corporate HTTP proxy
+pentest-kit proxy preset <name>          # saved preset from ~/.pentest-kit/proxies.yml
+pentest-kit proxy tor                    # anonymous research ONLY (heavy WAF failure rate)
 pentest-kit proxy chain <p1,p2,p3>       # chain proxies (type:host:port)
-pentest-kit proxy status                 # verify proxy active
-pentest-kit proxy off                    # direct connection
+pentest-kit proxy status                 # 4-check diagnostic (process/port/config/round-trip)
 
 # Scanning
 pentest-kit exec <command>               # run any tool inside container
@@ -152,15 +153,19 @@ pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json 
 
 1. **Executors NEVER attack directly.** They run tools from `tools/REGISTRY.md` following `tools/PIPELINES.md`.
 2. **All tools run inside the Docker container.** Use `pentest-kit exec <command>`. Never run tools on the host.
-3. **Proxy before scanning.** Always `pentest-kit proxy tor` (or socks5/http) before network scanning. Exception: `ssl` and `sast`/`sca` pipelines skip proxy automatically.
+3. **Choose a proxy mode explicitly per engagement.** Use the decision tree in `specs/PROXY.md`. Default for authorized pentest with IP whitelist is **direct** (`pentest-kit proxy off`). Tor is NOT the default — it fails against Cloudflare/Akamai/most production WAFs. Exception: `ssl`, `sast`, and `sca` pipelines skip proxy automatically.
 4. **Run tools from orchestrator directly** using `pentest-kit exec`. This is the primary pattern. Deploying parallel executor subagents is optional for independent pipelines.
 
 ## Startup Sequence (ALL MODES)
 
 ```
 1. pentest-kit init <engagement> --target <url>     ← creates dirs, starts container, runs preflight
-2. pentest-kit proxy tor                             ← activate proxy (MANDATORY)
-3. pentest-kit proxy status                          ← verify proxy is active
+2. Choose proxy mode for THIS engagement            ← see decision tree in specs/PROXY.md
+   • Authorized, IP whitelisted → pentest-kit proxy off
+   • Authorized, no whitelist   → pentest-kit proxy socks5 <vps>  (or preset)
+   • Bug bounty + residential   → pentest-kit proxy preset <name> (auth via env)
+   • Anonymous research         → pentest-kit proxy tor
+3. pentest-kit proxy status                          ← verify chosen mode actually works
 4. Proceed to scanning (Phase 2)
 ```
 
@@ -334,7 +339,7 @@ The CLI does NOT auto-generate content. It only combines and exports what the ag
 
 ## Critical Rules
 
-- **Proxy MANDATORY**: `pentest-kit proxy tor` before network scanning (ssl/sast/sca auto-skip)
+- **Choose proxy explicitly**: pick one mode per engagement via the decision tree in `specs/PROXY.md`. Direct (`proxy off`) is valid and often correct. Tor is rarely correct against production WAFs.
 - **Preflight MANDATORY**: `pentest-kit preflight` before every engagement
 - **User approval MANDATORY**: Present test plan and get approval before exploitation
 - **Tool-based only**: All commands from REGISTRY.md, all chains from PIPELINES.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     # Networking + Proxy
     net-tools \
+    iproute2 \
     iputils-ping \
     traceroute \
     tcpdump \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,21 @@ services:
     # --- Host isolation ---
     security_opt:
       - no-new-privileges:true      # can't escalate to HOST root
-    pid: host                         # needed for network_mode: host compatibility
-    ipc: shareable                   # isolated from host default namespace
+    ipc: shareable                  # isolated from host default namespace
+
+    # NOTE: `pid: host` was removed here. Sharing the host's PID namespace made
+    # the container see every host process — and, critically, made `pkill -x tor`
+    # inside `pentest-kit proxy off` kill the HOST's system tor. It also masked
+    # issue #42: `pentest-kit proxy tor` appeared to "work" on Kali hosts because
+    # the container was silently piggybacking on the host's system tor via the
+    # shared network namespace. Container-local PID isolation is required for
+    # honest proxy lifecycle management.
 
     # --- Network: host mode for scanning ---
-    # Required for: nmap raw sockets, port scanning, proxy binding
+    # Required for: nmap raw sockets, port scanning, proxy binding.
+    # Because of this, 127.0.0.1:9050 inside the container IS the host's
+    # loopback port 9050 — `pentest-kit proxy tor` will refuse to start if a
+    # host process is already bound there.
     network_mode: host
 
     # --- Volumes ---

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/docker"
 	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/engage"
 	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/preflight"
+	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/proxy"
 	"github.com/nunenuh/pentest-kit/pentest-kit-cli/internal/report"
 )
 
@@ -650,6 +651,83 @@ exit 1`
 				return fmt.Errorf("failed to configure proxychains: %w", err)
 			}
 			fmt.Printf("  ✓ proxychains4 → http://%s\n", args[0])
+			return nil
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "preset <name>",
+		Short: "Apply a saved proxy preset from ~/.pentest-kit/proxies.yml",
+		Long: "Apply a saved proxy preset. Presets live in ~/.pentest-kit/proxies.yml (mode 0600).\n" +
+			"Credentials MUST be referenced via auth_env (env var name), never inline.\n" +
+			"See specs/PROXY.md for the file format and decision tree.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := docker.FindWorkspace()
+			if err != nil {
+				return err
+			}
+			path, err := proxy.ConfigPath()
+			if err != nil {
+				return err
+			}
+			file, err := proxy.Load(path)
+			if err != nil {
+				return err
+			}
+			p, err := file.Get(args[0])
+			if err != nil {
+				return err
+			}
+			line, err := p.ProxychainsLine()
+			if err != nil {
+				return err
+			}
+
+			// Write config into the container. The credential-bearing line
+			// is passed via stdin to `tee`, not as a shell argument, so it
+			// never shows up in `ps` output on the host.
+			conf := "strict_chain\nproxy_dns\n[ProxyList]\n" + line + "\n"
+			writeCmd := []string{"bash", "-c", "cat > /etc/proxychains4.conf"}
+			if err := docker.ExecStdin(ws, writeCmd, conf); err != nil {
+				return fmt.Errorf("failed to configure proxychains: %w", err)
+			}
+
+			// Print a redacted summary. Never echo credentials.
+			redacted := fmt.Sprintf("%s %s %d", p.Type, p.Host, p.Port)
+			if p.AuthEnv != "" {
+				redacted += " (auth from $" + p.AuthEnv + ")"
+			}
+			fmt.Printf("  ✓ proxychains4 → preset %q: %s\n", p.Name, redacted)
+			fmt.Println("\n  Run `pentest-kit proxy status` to verify round-trip.")
+			return nil
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List saved proxy presets from ~/.pentest-kit/proxies.yml",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := proxy.ConfigPath()
+			if err != nil {
+				return err
+			}
+			file, err := proxy.Load(path)
+			if err != nil {
+				return err
+			}
+			if len(file.Presets) == 0 {
+				fmt.Println("No presets defined.")
+				return nil
+			}
+			fmt.Printf("Presets (%s):\n", path)
+			for name, p := range file.Presets {
+				auth := ""
+				if p.AuthEnv != "" {
+					auth = fmt.Sprintf(" (auth: $%s)", p.AuthEnv)
+				}
+				fmt.Printf("  %-24s %s %s:%d%s\n", name, p.Type, p.Host, p.Port, auth)
+			}
 			return nil
 		},
 	})

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -542,12 +542,34 @@ func proxyCmd() *cobra.Command {
 				return err
 			}
 			fast, _ := cmd.Flags().GetBool("fast")
+			reuseHost, _ := cmd.Flags().GetBool("reuse-host")
 
-			// Start tor as a proper daemon (double-forked, survives exec shell exit).
-			// Do NOT use `service tor start` — the container has no systemd, and it
-			// returns 0 without actually starting tor on some images.
-			fmt.Println("Starting Tor service...")
-			startCmd := `set -e
+			// Pre-check: is something (host tor, another pentest-kit, etc.) already
+			// listening on 127.0.0.1:9050? Because docker-compose.yml uses
+			// `network_mode: host`, the container shares the host's network
+			// namespace — so "our" 9050 is actually the host's loopback port.
+			// Silently clobbering it would be user-hostile.
+			portBoundCmd := `timeout 1 bash -c '</dev/tcp/127.0.0.1/9050' 2>/dev/null`
+			portAlreadyBound := docker.Exec(ws, []string{"bash", "-c", portBoundCmd}) == nil
+
+			if portAlreadyBound && !reuseHost {
+				return fmt.Errorf(
+					"port 127.0.0.1:9050 is already bound on the host (visible through " +
+						"`network_mode: host`).\n  " +
+						"This is usually the host system's `tor` service. Options:\n  " +
+						"  1. Reuse it:           pentest-kit proxy tor --reuse-host\n  " +
+						"  2. Stop host tor:      sudo systemctl stop tor  (then retry)\n  " +
+						"  3. Inspect the owner:  ss -ltnp | grep 9050  (on the host)")
+			}
+
+			if reuseHost && portAlreadyBound {
+				fmt.Println("  → Reusing existing tor on 127.0.0.1:9050 (--reuse-host)")
+			} else {
+				// Start tor as a proper daemon (double-forked, survives exec shell exit).
+				// Do NOT use `service tor start` — the container has no systemd, and it
+				// returns 0 without actually starting tor on some images.
+				fmt.Println("Starting Tor service...")
+				startCmd := `set -e
 pkill -x tor 2>/dev/null || true
 rm -f /var/run/tor.pid 2>/dev/null || true
 mkdir -p /var/log /var/run
@@ -561,8 +583,9 @@ done
 echo "tor failed to bind 127.0.0.1:9050 after 10s" >&2
 tail -20 /var/log/tor.log 2>/dev/null >&2 || true
 exit 1`
-			if err := docker.Exec(ws, []string{"bash", "-c", startCmd}); err != nil {
-				return fmt.Errorf("failed to start tor: %w", err)
+				if err := docker.Exec(ws, []string{"bash", "-c", startCmd}); err != nil {
+					return fmt.Errorf("failed to start tor: %w", err)
+				}
 			}
 
 			// Configure proxychains for tor (socks5 127.0.0.1 9050)
@@ -592,6 +615,7 @@ exit 1`
 		},
 	}
 	torCmd.Flags().Bool("fast", false, "Skip end-to-end SOCKS5 round-trip verification (offline/CI dev loops)")
+	torCmd.Flags().Bool("reuse-host", false, "Reuse a tor instance already listening on 127.0.0.1:9050 (host system tor)")
 	cmd.AddCommand(torCmd)
 
 	cmd.AddCommand(&cobra.Command{
@@ -666,8 +690,20 @@ exit 1`
 			if err != nil {
 				return err
 			}
-			// Stop tor daemon if running (no systemd in container — kill directly)
-			_ = docker.Exec(ws, []string{"bash", "-c", "pkill -x tor 2>/dev/null; rm -f /var/run/tor.pid 2>/dev/null; true"})
+			// Stop only the tor daemon we started (identified by /var/run/tor.pid
+			// written by `proxy tor`). Never `pkill -x tor` blindly: on hosts with
+			// network_mode: host + a running system tor, pkill would reach across
+			// the netns boundary via shared PID namespace in older configs and
+			// kill the user's host tor. PID-file-only is the safe contract.
+			stopCmd := `if [ -f /var/run/tor.pid ]; then
+  pid=$(cat /var/run/tor.pid 2>/dev/null)
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+  rm -f /var/run/tor.pid 2>/dev/null || true
+fi
+true`
+			_ = docker.Exec(ws, []string{"bash", "-c", stopCmd})
 			// Reset proxychains to commented-out default
 			conf := "# proxy disabled\n# strict_chain\n# [ProxyList]\n# socks5 127.0.0.1 9050\n"
 			_ = docker.Exec(ws, []string{"bash", "-c", fmt.Sprintf("echo '%s' > /etc/proxychains4.conf", conf)})

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -533,7 +533,7 @@ func proxyCmd() *cobra.Command {
 		Short: "Configure outbound proxy for tool traffic (proxychains + tor)",
 	}
 
-	cmd.AddCommand(&cobra.Command{
+	torCmd := &cobra.Command{
 		Use:   "tor",
 		Short: "Route all tool traffic through Tor",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -541,23 +541,58 @@ func proxyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Start tor service
+			fast, _ := cmd.Flags().GetBool("fast")
+
+			// Start tor as a proper daemon (double-forked, survives exec shell exit).
+			// Do NOT use `service tor start` — the container has no systemd, and it
+			// returns 0 without actually starting tor on some images.
 			fmt.Println("Starting Tor service...")
-			if err := docker.Exec(ws, []string{"bash", "-c", "service tor start 2>/dev/null || tor &"}); err != nil {
+			startCmd := `set -e
+pkill -x tor 2>/dev/null || true
+rm -f /var/run/tor.pid 2>/dev/null || true
+mkdir -p /var/log /var/run
+tor --RunAsDaemon 1 --PidFile /var/run/tor.pid --Log "notice file /var/log/tor.log" >/dev/null 2>&1
+for i in $(seq 1 20); do
+  if timeout 1 bash -c '</dev/tcp/127.0.0.1/9050' 2>/dev/null; then
+    exit 0
+  fi
+  sleep 0.5
+done
+echo "tor failed to bind 127.0.0.1:9050 after 10s" >&2
+tail -20 /var/log/tor.log 2>/dev/null >&2 || true
+exit 1`
+			if err := docker.Exec(ws, []string{"bash", "-c", startCmd}); err != nil {
 				return fmt.Errorf("failed to start tor: %w", err)
 			}
+
 			// Configure proxychains for tor (socks5 127.0.0.1 9050)
 			conf := "strict_chain\nproxy_dns\n[ProxyList]\nsocks5 127.0.0.1 9050\n"
 			if err := docker.Exec(ws, []string{"bash", "-c", fmt.Sprintf("echo '%s' > /etc/proxychains4.conf", conf)}); err != nil {
 				return fmt.Errorf("failed to configure proxychains: %w", err)
 			}
-			fmt.Println("  ✓ Tor running on socks5://127.0.0.1:9050")
+
+			fmt.Println("  ✓ Tor daemonized, listening on 127.0.0.1:9050")
+
+			// End-to-end verification: real SOCKS5 round-trip
+			if !fast {
+				fmt.Println("  → Verifying SOCKS5 round-trip via check.torproject.org...")
+				verifyCmd := `curl -sS --socks5-hostname 127.0.0.1:9050 --max-time 30 https://check.torproject.org/api/ip | grep -q IsTor`
+				if err := docker.Exec(ws, []string{"bash", "-c", verifyCmd}); err != nil {
+					return fmt.Errorf("tor bound 9050 but SOCKS5 round-trip failed — check container egress: %w", err)
+				}
+				fmt.Println("  ✓ SOCKS5 round-trip verified")
+			} else {
+				fmt.Println("  ⚠ Skipping SOCKS5 round-trip verification (--fast)")
+			}
+
 			fmt.Println("  ✓ proxychains4 configured")
 			fmt.Println("\n  Use: pentest-kit exec proxychains4 nmap ...")
 			fmt.Println("  Or:  pentest-kit exec --proxy nmap ...")
 			return nil
 		},
-	})
+	}
+	torCmd.Flags().Bool("fast", false, "Skip end-to-end SOCKS5 round-trip verification (offline/CI dev loops)")
+	cmd.AddCommand(torCmd)
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "socks5 <host:port>",
@@ -631,8 +666,8 @@ func proxyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Stop tor if running
-			_ = docker.Exec(ws, []string{"bash", "-c", "service tor stop 2>/dev/null; killall tor 2>/dev/null"})
+			// Stop tor daemon if running (no systemd in container — kill directly)
+			_ = docker.Exec(ws, []string{"bash", "-c", "pkill -x tor 2>/dev/null; rm -f /var/run/tor.pid 2>/dev/null; true"})
 			// Reset proxychains to commented-out default
 			conf := "# proxy disabled\n# strict_chain\n# [ProxyList]\n# socks5 127.0.0.1 9050\n"
 			_ = docker.Exec(ws, []string{"bash", "-c", fmt.Sprintf("echo '%s' > /etc/proxychains4.conf", conf)})
@@ -643,19 +678,33 @@ func proxyCmd() *cobra.Command {
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "status",
-		Short: "Show current proxy configuration",
+		Short: "Show real proxy state (process, port, config, SOCKS5 round-trip)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := docker.FindWorkspace()
 			if err != nil {
 				return err
 			}
 			fmt.Println("Proxy status:")
-			// Check tor
-			out, _ := docker.ExecCapture(ws, []string{"bash", "-c", "pgrep tor >/dev/null 2>&1 && echo 'running' || echo 'stopped'"})
-			fmt.Printf("  Tor: %s\n", strings.TrimSpace(out))
-			// Show proxychains config
-			out, _ = docker.ExecCapture(ws, []string{"bash", "-c", "grep -v '^#' /etc/proxychains4.conf 2>/dev/null | grep -v '^$' || echo 'not configured'"})
-			fmt.Printf("  Proxychains:\n    %s\n", strings.ReplaceAll(strings.TrimSpace(out), "\n", "\n    "))
+
+			// tor process
+			out, _ := docker.ExecCapture(ws, []string{"bash", "-c", "pgrep -x tor >/dev/null && echo \"running (pid $(pgrep -x tor))\" || echo 'NOT RUNNING'"})
+			fmt.Printf("  tor process:       %s\n", strings.TrimSpace(out))
+
+			// port 9050 bound
+			out, _ = docker.ExecCapture(ws, []string{"bash", "-c", "timeout 2 bash -c '</dev/tcp/127.0.0.1/9050' 2>/dev/null && echo 'listening' || echo 'NOT LISTENING'"})
+			fmt.Printf("  port 9050:         %s\n", strings.TrimSpace(out))
+
+			// proxychains config
+			out, _ = docker.ExecCapture(ws, []string{"bash", "-c", "[ -f /etc/proxychains4.conf ] && grep -q '^socks5 127.0.0.1 9050' /etc/proxychains4.conf && echo 'configured (tor)' || ([ -f /etc/proxychains4.conf ] && echo 'configured (custom)' || echo 'NOT CONFIGURED')"})
+			fmt.Printf("  proxychains:       %s\n", strings.TrimSpace(out))
+
+			// end-to-end SOCKS5 round-trip
+			out, _ = docker.ExecCapture(ws, []string{"bash", "-c", "curl -sS --socks5-hostname 127.0.0.1:9050 --max-time 10 https://check.torproject.org/api/ip 2>/dev/null | grep -q IsTor && echo 'OK' || echo 'FAILED'"})
+			fmt.Printf("  SOCKS5 round-trip: %s\n", strings.TrimSpace(out))
+
+			// raw proxychains config dump
+			out, _ = docker.ExecCapture(ws, []string{"bash", "-c", "grep -v '^#' /etc/proxychains4.conf 2>/dev/null | grep -v '^$' || echo 'none'"})
+			fmt.Printf("  proxychains.conf:\n    %s\n", strings.ReplaceAll(strings.TrimSpace(out), "\n", "\n    "))
 			return nil
 		},
 	})

--- a/pentest-kit-cli/go.mod
+++ b/pentest-kit-cli/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.8.1
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pentest-kit-cli/go.sum
+++ b/pentest-kit-cli/go.sum
@@ -7,4 +7,5 @@ github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3k
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pentest-kit-cli/internal/docker/docker.go
+++ b/pentest-kit-cli/internal/docker/docker.go
@@ -164,6 +164,22 @@ func ExecWithEnv(workspace string, args []string, envVars []string) error {
 	return cmd.Run()
 }
 
+// ExecStdin runs a command inside the container and pipes `input` to its
+// stdin. Use this to pass credential-bearing data (e.g. proxychains config
+// with auth) without exposing it in the host's process list.
+func ExecStdin(workspace string, args []string, input string) error {
+	if !IsRunning(workspace) {
+		return fmt.Errorf("container not running. Run: pentest-kit up")
+	}
+	dockerArgs := append([]string{"compose", "exec", "-T", "pentest-kit"}, args...)
+	cmd := exec.Command("docker", dockerArgs...)
+	cmd.Dir = workspace
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // ExecCapture runs a command inside the container and captures stdout.
 func ExecCapture(workspace string, args []string) (string, error) {
 	if !IsRunning(workspace) {

--- a/pentest-kit-cli/internal/proxy/preset.go
+++ b/pentest-kit-cli/internal/proxy/preset.go
@@ -1,0 +1,159 @@
+// Package proxy loads and validates user proxy presets from
+// ~/.pentest-kit/proxies.yml. Presets let users save common proxy
+// configurations (VPS SOCKS5, corporate HTTP, residential proxies) and
+// apply them per engagement without retyping host:port every time.
+//
+// Security contract:
+//
+//   - Credentials MUST come from environment variables via `auth_env`.
+//     Inline `auth` fields are rejected at load time.
+//   - The preset file MUST NOT be world- or group-readable on Unix
+//     (mode 0600 or 0400 required). A more permissive mode is rejected.
+//   - Credential values are never written to disk inside the container.
+//     They are injected at runtime via `docker compose exec -e`.
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Preset is a single named proxy configuration.
+type Preset struct {
+	Name    string `yaml:"-"`
+	Type    string `yaml:"type"`     // "socks5" | "http"
+	Host    string `yaml:"host"`
+	Port    int    `yaml:"port"`
+	AuthEnv string `yaml:"auth_env"` // name of env var holding "user:pass"
+	// NOTE: no inline Auth field — deliberately omitted so YAML unmarshal
+	// rejects any `auth:` key via KnownFields strict mode below.
+}
+
+// File is the top-level YAML schema.
+type File struct {
+	Presets map[string]*Preset `yaml:"presets"`
+}
+
+// ConfigPath returns the default preset file location.
+func ConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".pentest-kit", "proxies.yml"), nil
+}
+
+// Load reads and validates the preset file. Returns a helpful error if
+// the file doesn't exist or the mode is too permissive.
+func Load(path string) (*File, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"no preset file at %s\n"+
+					"  Create one with:\n"+
+					"    mkdir -p ~/.pentest-kit && touch ~/.pentest-kit/proxies.yml\n"+
+					"    chmod 600 ~/.pentest-kit/proxies.yml\n"+
+					"  See specs/PROXY.md for the file format.",
+				path)
+		}
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	// Unix: require the file to be tightly locked down. Windows does not
+	// expose the same mode bits, so we skip the check there.
+	if runtime.GOOS != "windows" {
+		mode := info.Mode().Perm()
+		if mode&0o077 != 0 {
+			return nil, fmt.Errorf(
+				"%s has permissions %#o — must be 0600 or 0400 (no group/other access)\n"+
+					"  Fix: chmod 600 %s",
+				path, mode, path)
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var file File
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	dec.KnownFields(true) // reject unknown keys like `auth:`
+	if err := dec.Decode(&file); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	// Backfill the Name field and validate each preset.
+	for name, p := range file.Presets {
+		if p == nil {
+			return nil, fmt.Errorf("preset %q is empty", name)
+		}
+		p.Name = name
+		if err := p.Validate(); err != nil {
+			return nil, fmt.Errorf("preset %q: %w", name, err)
+		}
+	}
+
+	return &file, nil
+}
+
+// Validate checks that a single preset has all required fields set and
+// that its type is supported. It does NOT read environment variables —
+// that happens at apply time so `proxy list` works without credentials.
+func (p *Preset) Validate() error {
+	switch p.Type {
+	case "socks5", "http":
+	case "":
+		return fmt.Errorf("type is required (socks5 or http)")
+	default:
+		return fmt.Errorf("unsupported type %q (want socks5 or http)", p.Type)
+	}
+	if p.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+	if p.Port <= 0 || p.Port > 65535 {
+		return fmt.Errorf("port must be 1-65535, got %d", p.Port)
+	}
+	return nil
+}
+
+// Get returns a preset by name or a helpful error listing available names.
+func (f *File) Get(name string) (*Preset, error) {
+	p, ok := f.Presets[name]
+	if !ok {
+		names := make([]string, 0, len(f.Presets))
+		for n := range f.Presets {
+			names = append(names, n)
+		}
+		return nil, fmt.Errorf("preset %q not found. Available: %s", name, strings.Join(names, ", "))
+	}
+	return p, nil
+}
+
+// ProxychainsLine returns the single line to append to the
+// [ProxyList] section of /etc/proxychains4.conf for this preset,
+// with credentials resolved from the environment at call time.
+// Returns an error if AuthEnv is set but the env var is empty.
+func (p *Preset) ProxychainsLine() (string, error) {
+	line := fmt.Sprintf("%s %s %d", p.Type, p.Host, p.Port)
+	if p.AuthEnv != "" {
+		creds := os.Getenv(p.AuthEnv)
+		if creds == "" {
+			return "", fmt.Errorf(
+				"preset %q requires env var %s to be set (format: user:pass)",
+				p.Name, p.AuthEnv)
+		}
+		parts := strings.SplitN(creds, ":", 2)
+		if len(parts) != 2 {
+			return "", fmt.Errorf("env var %s must be 'user:pass', got %q", p.AuthEnv, creds)
+		}
+		line = fmt.Sprintf("%s %s %d %s %s", p.Type, p.Host, p.Port, parts[0], parts[1])
+	}
+	return line, nil
+}

--- a/pentest-kit-cli/internal/proxy/preset_test.go
+++ b/pentest-kit-cli/internal/proxy/preset_test.go
@@ -1,0 +1,158 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writePreset(t *testing.T, content string, mode os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "proxies.yml")
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoad_ValidSocks5(t *testing.T) {
+	path := writePreset(t, `
+presets:
+  vps:
+    type: socks5
+    host: 203.0.113.42
+    port: 1080
+`, 0o600)
+
+	file, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, err := file.Get("vps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Type != "socks5" || p.Host != "203.0.113.42" || p.Port != 1080 {
+		t.Errorf("bad preset: %+v", p)
+	}
+}
+
+func TestLoad_RejectsInlineAuth(t *testing.T) {
+	// KnownFields strict mode must reject an unknown `auth` key.
+	path := writePreset(t, `
+presets:
+  bad:
+    type: socks5
+    host: 1.2.3.4
+    port: 1080
+    auth: user:pass
+`, 0o600)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for inline auth, got nil")
+	}
+	if !strings.Contains(err.Error(), "auth") {
+		t.Errorf("error should mention 'auth', got: %v", err)
+	}
+}
+
+func TestLoad_RejectsWorldReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode check only")
+	}
+	path := writePreset(t, `presets:
+  vps:
+    type: socks5
+    host: 1.2.3.4
+    port: 1080
+`, 0o644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for world-readable file")
+	}
+	if !strings.Contains(err.Error(), "0600") {
+		t.Errorf("error should suggest chmod 600, got: %v", err)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "nope.yml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestValidate_BadPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		preset  Preset
+		wantErr string
+	}{
+		{"zero", Preset{Type: "socks5", Host: "h", Port: 0}, "port"},
+		{"negative", Preset{Type: "socks5", Host: "h", Port: -1}, "port"},
+		{"too big", Preset{Type: "socks5", Host: "h", Port: 70000}, "port"},
+		{"no type", Preset{Host: "h", Port: 1080}, "type"},
+		{"bad type", Preset{Type: "tor", Host: "h", Port: 1080}, "unsupported type"},
+		{"no host", Preset{Type: "socks5", Port: 1080}, "host"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.preset.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestProxychainsLine_NoAuth(t *testing.T) {
+	p := &Preset{Name: "vps", Type: "socks5", Host: "1.2.3.4", Port: 1080}
+	line, err := p.ProxychainsLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "socks5 1.2.3.4 1080" {
+		t.Errorf("got %q", line)
+	}
+}
+
+func TestProxychainsLine_WithAuth(t *testing.T) {
+	t.Setenv("TEST_CREDS", "alice:secret")
+	p := &Preset{Name: "vps", Type: "socks5", Host: "1.2.3.4", Port: 1080, AuthEnv: "TEST_CREDS"}
+	line, err := p.ProxychainsLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "socks5 1.2.3.4 1080 alice secret" {
+		t.Errorf("got %q", line)
+	}
+}
+
+func TestProxychainsLine_MissingEnvVar(t *testing.T) {
+	t.Setenv("TEST_CREDS", "")
+	p := &Preset{Name: "vps", Type: "socks5", Host: "h", Port: 1080, AuthEnv: "TEST_CREDS"}
+	if _, err := p.ProxychainsLine(); err == nil {
+		t.Fatal("want error for empty env var")
+	}
+}
+
+func TestProxychainsLine_MalformedCreds(t *testing.T) {
+	t.Setenv("TEST_CREDS", "not-user-colon-pass")
+	p := &Preset{Name: "vps", Type: "socks5", Host: "h", Port: 1080, AuthEnv: "TEST_CREDS"}
+	if _, err := p.ProxychainsLine(); err == nil {
+		t.Fatal("want error for malformed creds")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	f := &File{Presets: map[string]*Preset{"a": {Type: "socks5", Host: "h", Port: 1}}}
+	_, err := f.Get("missing")
+	if err == nil || !strings.Contains(err.Error(), "Available") {
+		t.Errorf("expected 'Available' in error, got %v", err)
+	}
+}

--- a/specs/PROXY.md
+++ b/specs/PROXY.md
@@ -1,28 +1,108 @@
 # Proxy
 
-## Why
+## Choose the Right Proxy (Read First)
 
-All scanning traffic should go through a proxy to:
-- Avoid source IP being blocked by WAF/IDS
-- Maintain anonymity during authorized testing
-- Route through specific geographic locations
-- Chain multiple proxies for defense-in-depth
+**There is no universal "correct" proxy for pentesting.** The proxy you use depends on the engagement type, target stack, and legal footing. Picking the wrong one will silently destroy your scan results — WAFs return empty pages, tools look "broken", and findings dry up.
+
+### Decision tree
+
+```
+Is this an authorized engagement with a signed SOW / ROE?
+├── YES — did the client whitelist your source IP?
+│   ├── YES → DIRECT (no proxy). Whitelisting is the point. Fastest, most
+│   │         reliable, proper attribution for defender logs.
+│   │         →  pentest-kit proxy off
+│   │
+│   └── NO  → SOCKS5 to your own VPS (stable IP, you can hand that IP to
+│             the client for their WAF allowlist). $5/mo on Hetzner/DO.
+│             →  pentest-kit proxy socks5 <vps-ip>:1080
+│             →  or:  pentest-kit proxy preset <name>
+│
+└── NO — is this bug bounty or anonymous research?
+    ├── Bug bounty, need IP rotation and WAF evasion
+    │   → Residential SOCKS5 (BrightData, Smartproxy, Oxylabs).
+    │     ~$10+/GB. Read credentials from env vars, NEVER hardcode.
+    │     →  export BRD_CREDS=user:pass
+    │     →  pentest-kit proxy socks5 brd.superproxy.io:22225
+    │
+    └── Anonymous research / takedown territory
+        → Tor. Accept ~50% tool failure rate against Cloudflare/Akamai
+          and slow scans. This is the tool of last resort, not default.
+          →  pentest-kit proxy tor
+```
+
+### Proxy comparison matrix
+
+| Proxy | Cost | Speed | WAF bypass | Attribution | Best for |
+|-------|------|-------|-----------|-------------|----------|
+| **Direct** | free | fastest | N/A | clean | Authorized pentest with IP whitelist |
+| **Personal VPS SOCKS5** | ~$5/mo | fast | low | stable | Authorized pentest without whitelist |
+| **Residential SOCKS5** | $10+/GB | medium | high | rotating | Bug bounty at scale, heavy WAF targets |
+| **Corporate HTTP proxy** | free (mandated) | varies | N/A | corporate egress | Red team internal engagements |
+| **Tor** | free | slow | very low | anonymous | Anonymous research only |
+| **Chain (tor → residential)** | $10+/GB | slowest | high | anonymous | Maximum anonymity + WAF bypass |
+
+### Does the target accept tor?
+
+**Usually not.** The following actively block or challenge tor exit nodes:
+
+- **Cloudflare** — mandatory hCaptcha challenge on most sites (tools can't solve it → 403)
+- **Akamai Bot Manager, Kasada, PerimeterX** — explicit tor blocklist
+- **AWS WAF** — "Anonymous IP List" managed rule blocks all known tor exits
+- **Most banks, payment processors, Google, Facebook** — hard block or stepped-up auth
+
+**Symptoms you're being WAF'd through tor:** katana/gau return 0 results, nuclei finds nothing on a known-vuln target, ffuf returns wall-to-wall 403s, scans "succeed" with empty output. That's not a tool bug — that's the WAF.
+
+**Rule of thumb:** on an authorized pentest, tor is almost never the right answer. Use direct or your VPS. Reserve tor for the rare case where you need source-IP anonymity and accept the cost.
 
 ## Tools in Container
 
 - **proxychains4** — wraps any command to route through configured proxy
-- **tor** — SOCKS5 proxy on 127.0.0.1:9050
+- **tor** — SOCKS5 proxy on 127.0.0.1:9050 (available, not required)
 
 ## Commands
 
 ```bash
 pentest-kit proxy tor                              # start tor, configure proxychains
-pentest-kit proxy socks5 host:port                 # SOCKS5 proxy
-pentest-kit proxy http host:port                   # HTTP proxy
+pentest-kit proxy socks5 host:port                 # SOCKS5 proxy (VPS, residential, etc.)
+pentest-kit proxy http host:port                   # HTTP proxy (corporate, burp, etc.)
 pentest-kit proxy chain socks5:h1:p1,http:h2:p2    # chain multiple proxies
-pentest-kit proxy status                           # verify proxy active
+pentest-kit proxy preset <name>                    # apply a saved preset (see Presets below)
+pentest-kit proxy status                           # 4-check diagnostic (process/port/config/round-trip)
 pentest-kit proxy off                              # direct connection
 ```
+
+## Presets (`~/.pentest-kit/proxies.yml`)
+
+Instead of retyping your VPS SOCKS5 address every engagement, save it as a preset:
+
+```yaml
+# ~/.pentest-kit/proxies.yml
+presets:
+  hetzner-fsn1:
+    type: socks5
+    host: 203.0.113.42
+    port: 1080
+  brightdata-residential:
+    type: socks5
+    host: brd.superproxy.io
+    port: 22225
+    # auth is read from the BRD_CREDS env var at runtime — NEVER hardcode
+    auth_env: BRD_CREDS
+  corp-egress:
+    type: http
+    host: proxy.corp.internal
+    port: 3128
+```
+
+Then:
+
+```bash
+pentest-kit proxy preset hetzner-fsn1
+pentest-kit proxy status            # verify before scanning
+```
+
+**Security:** proxy credentials MUST come from environment variables (`auth_env`), never from the YAML file. The CLI refuses to load a preset with inline credentials.
 
 ## How It Works
 
@@ -54,12 +134,29 @@ pentest-kit proxy off                              # direct connection
    - ffuf: `-x socks5://127.0.0.1:9050`
    - dalfox: `--proxy socks5://127.0.0.1:9050`
 
-## Mandatory Rule
+## The Startup Rule
 
-Proxy activation is **mandatory** before any network scanning. The startup sequence is:
+Before scanning, you MUST explicitly choose a proxy mode for the engagement. "Direct" is a valid and often correct choice — it's still a choice.
 
 ```
-pentest-kit init → pentest-kit proxy tor → pentest-kit proxy status → scan
+pentest-kit init → choose proxy mode → pentest-kit proxy status → scan
+```
+
+Examples:
+
+```bash
+# Authorized pentest, client whitelisted your IP → direct
+pentest-kit proxy off && pentest-kit proxy status
+
+# Authorized pentest, no whitelist → your VPS
+pentest-kit proxy preset hetzner-fsn1 && pentest-kit proxy status
+
+# Bug bounty, residential rotation
+export BRD_CREDS=user:pass
+pentest-kit proxy preset brightdata-residential && pentest-kit proxy status
+
+# Anonymous research
+pentest-kit proxy tor && pentest-kit proxy status
 ```
 
 `pentest-kit proxy status` reports four independent checks — **use it to diagnose proxy failures**, not the config file alone:

--- a/specs/PROXY.md
+++ b/specs/PROXY.md
@@ -26,13 +26,17 @@ pentest-kit proxy off                              # direct connection
 
 ## How It Works
 
-1. `pentest-kit proxy tor` starts the tor service and writes `/etc/proxychains4.conf`:
+1. `pentest-kit proxy tor` starts tor as a **double-forked daemon** (`tor --RunAsDaemon 1 --PidFile /var/run/tor.pid`), waits up to 10s for 9050 to bind, then performs an **end-to-end SOCKS5 round-trip** against `check.torproject.org` before printing success. It writes `/etc/proxychains4.conf`:
    ```
    strict_chain
    proxy_dns
    [ProxyList]
    socks5 127.0.0.1 9050
    ```
+
+   Pass `--fast` to skip the SOCKS5 round-trip (offline / CI dev loops).
+
+   > **Why a daemon?** The container has no systemd. Previous versions used `service tor start || tor &` which silently died the moment the `docker exec` shell exited, leaving subsequent scans to hit a dead proxy. See GitHub issue #42 for history.
 
 2. Tool commands are prefixed with `proxychains4 -q`:
    ```bash
@@ -54,6 +58,17 @@ Proxy activation is **mandatory** before any network scanning. The startup seque
 pentest-kit init → pentest-kit proxy tor → pentest-kit proxy status → scan
 ```
 
+`pentest-kit proxy status` reports four independent checks — **use it to diagnose proxy failures**, not the config file alone:
+
+```
+  tor process:       running (pid 1234)
+  port 9050:         listening
+  proxychains:       configured (tor)
+  SOCKS5 round-trip: OK
+```
+
+If `SOCKS5 round-trip` is `FAILED` but `tor process` is `running`, your container has no egress to `check.torproject.org` (firewall, DNS, or exit node issue). If `tor process` is `NOT RUNNING` after `proxy tor`, file a bug with `tail /var/log/tor.log` from inside the container.
+
 ## Tool Proxy Compatibility
 
 Not all tools work through proxychains/Tor. The CLI auto-skips proxy for incompatible pipelines.
@@ -68,8 +83,8 @@ Not all tools work through proxychains/Tor. The CLI auto-skips proxy for incompa
 | subfinder | Yes | N/A | DNS-based, works |
 | httpx | Partial | N/A | May fail with `-cdn` flag |
 | testssl.sh | **No** | N/A | Does own TLS handshake — incompatible with SOCKS5 |
-| katana | **Poor** | N/A | Often returns 0 results through Tor |
-| gau | **Poor** | N/A | API-based, Tor exit nodes often blocked |
+| katana | Partial | N/A | Empty results often mean tor isn't actually running — run `pentest-kit proxy status` first |
+| gau | Partial | N/A | Same as katana — verify real proxy state via `proxy status` before blaming exit nodes |
 | semgrep | N/A | N/A | Local analysis, no network |
 | trivy | N/A | N/A | Local analysis, no network |
 | bandit | N/A | N/A | Local analysis, no network |

--- a/specs/PROXY.md
+++ b/specs/PROXY.md
@@ -26,7 +26,7 @@ pentest-kit proxy off                              # direct connection
 
 ## How It Works
 
-1. `pentest-kit proxy tor` starts tor as a **double-forked daemon** (`tor --RunAsDaemon 1 --PidFile /var/run/tor.pid`), waits up to 10s for 9050 to bind, then performs an **end-to-end SOCKS5 round-trip** against `check.torproject.org` before printing success. It writes `/etc/proxychains4.conf`:
+1. `pentest-kit proxy tor` first checks whether 127.0.0.1:9050 is **already bound** on the host (the container runs with `network_mode: host`, so 127.0.0.1 is shared). If yes, it refuses to start and suggests either `--reuse-host` or stopping the host's tor. If no, it starts tor as a **double-forked daemon** (`tor --RunAsDaemon 1 --PidFile /var/run/tor.pid`), waits up to 10s for 9050 to bind, then performs an **end-to-end SOCKS5 round-trip** against `check.torproject.org` before printing success. It writes `/etc/proxychains4.conf`:
    ```
    strict_chain
    proxy_dns
@@ -34,9 +34,13 @@ pentest-kit proxy off                              # direct connection
    socks5 127.0.0.1 9050
    ```
 
-   Pass `--fast` to skip the SOCKS5 round-trip (offline / CI dev loops).
+   Flags:
+   - `--fast` — skip the SOCKS5 round-trip (offline / CI dev loops)
+   - `--reuse-host` — piggyback on an existing host tor already listening on 9050
 
-   > **Why a daemon?** The container has no systemd. Previous versions used `service tor start || tor &` which silently died the moment the `docker exec` shell exited, leaving subsequent scans to hit a dead proxy. See GitHub issue #42 for history.
+   > **Why a daemon?** The container has no systemd. Previous versions used `service tor start || tor &` which silently died the moment the `docker exec` shell exited, leaving subsequent scans to hit a dead proxy. On machines where the host had a system tor running, the bug was invisible — the container's `network_mode: host` silently piggybacked on the host service. See GitHub issue #42 for history.
+   >
+   > **Why PID-file-only on `proxy off`?** Earlier versions ran `pkill -x tor` on shutdown. Combined with the old `pid: host` docker-compose setting, that call could **kill the host's system tor**. The PID namespace is now container-local, and `proxy off` only stops the PID recorded in `/var/run/tor.pid` by `proxy tor` — so `--reuse-host` and externally-started tor instances are left alone.
 
 2. Tool commands are prefixed with `proxychains4 -q`:
    ```bash


### PR DESCRIPTION
Closes #42.

## Summary

`pentest-kit proxy tor` was printing success while tor had already died. This fixes the three compounding bugs:

1. **Tor dying with the exec shell** — replaced `service tor start || tor &` with `tor --RunAsDaemon 1 --PidFile /var/run/tor.pid`. The daemon double-forks and survives the parent shell exit.
2. **No real verification before success** — now waits up to 10s for port 9050 to bind, then performs an end-to-end SOCKS5 round-trip against `check.torproject.org`. Fails loudly if anything is off.
3. **`proxy status` only read the config file** — now reports four independent checks: tor process, port 9050 bind, proxychains config, live SOCKS5 round-trip.

Also fixes `proxy off` to use `pkill -x tor` (the container has no systemd, so `service tor stop` was a no-op).

Added `--fast` flag on `proxy tor` to skip the SOCKS5 round-trip for offline / CI dev loops.

## Test plan

- [ ] `pentest-kit up && pentest-kit proxy tor` — should print `✓ SOCKS5 round-trip verified`
- [ ] `pentest-kit exec bash -c 'pgrep -x tor'` — should return a PID
- [ ] `pentest-kit exec bash -c '</dev/tcp/127.0.0.1/9050'` — should succeed
- [ ] `pentest-kit exec proxychains4 -q curl -sS https://check.torproject.org/api/ip` — should return `{"IsTor":true,...}`
- [ ] `pentest-kit proxy status` — all four rows show running / listening / configured / OK
- [ ] `pentest-kit proxy off && pentest-kit proxy status` — tor process NOT RUNNING, port NOT LISTENING
- [ ] `pentest-kit proxy tor --fast` — skips round-trip verification