### PR TITLE
feat(install): support CLAUDE_HOME for multi-profile setups #46

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
   go-binaries:
     name: Build Go CLI Binaries
     needs: release
-    if: needs.release.outputs.new_release == 'true' && github.ref == 'refs/heads/main'
+    if: needs.release.outputs.new_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/install-remote.sh
+++ b/install-remote.sh
@@ -8,6 +8,8 @@
 #   CLAUDE_HOME=~/.claude,~/.claude-work — install to multiple (comma-separated)
 #   PENTEST_KIT_NO_DOCKER=1             — skip Docker image pull
 #   PENTEST_KIT_VERSION=v0.1.0          — install specific version (default: latest)
+#   PENTEST_KIT_VERSION=dev             — install from dev branch (latest, pre-release)
+#   PENTEST_KIT_VERSION=main            — install from main branch HEAD
 #
 # Multi-profile: if multiple ~/.claude* dirs exist, the installer prompts
 # you to choose (or "all"). Override with CLAUDE_HOME to skip the prompt.
@@ -148,10 +150,12 @@ fi
 
 echo -e "  Version: ${BOLD}$VERSION${NC}"
 
-if [ "$VERSION" = "main" ]; then
-    # Download from main branch
-    DOWNLOAD_URL="https://github.com/$REPO/archive/refs/heads/main.tar.gz"
-    EXTRACT_DIR="pentest-kit-main"
+if [ "$VERSION" = "main" ] || [ "$VERSION" = "dev" ]; then
+    # Download from a branch (main or dev)
+    BRANCH="$VERSION"
+    DOWNLOAD_URL="https://github.com/$REPO/archive/refs/heads/$BRANCH.tar.gz"
+    EXTRACT_DIR="pentest-kit-$BRANCH"
+    echo -e "  ${YELLOW}[BRANCH]${NC} Installing from $BRANCH branch (not a release)"
 else
     # Try release asset first, fallback to source archive
     ASSET_URL="https://github.com/$REPO/releases/download/$VERSION/pentest-kit-$VERSION.tar.gz"
@@ -307,8 +311,11 @@ esac
 
 if [ -n "$CLI_OS" ] && [ -n "$CLI_ARCH" ]; then
     # Determine CLI version to download (strip leading 'v' for asset name)
-    if [ "$VERSION" = "main" ]; then
+    if [ "$VERSION" = "main" ] || [ "$VERSION" = "dev" ]; then
         CLI_VERSION=$(curl -sSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+        if [ "$VERSION" = "dev" ]; then
+            echo -e "  ${YELLOW}[NOTE]${NC} dev branch — CLI binary from latest release ($CLI_VERSION)"
+        fi
     else
         CLI_VERSION="$VERSION"
     fi

--- a/install-remote.sh
+++ b/install-remote.sh
@@ -4,8 +4,13 @@
 #    or: curl -sSL https://raw.githubusercontent.com/nunenuh/pentest-kit/main/install-remote.sh | bash
 #
 # Options (pass as env vars):
-#   PENTEST_KIT_NO_DOCKER=1  — skip Docker image pull
-#   PENTEST_KIT_VERSION=v0.1.0 — install specific version (default: latest)
+#   CLAUDE_HOME=~/.claude-work          — install to a specific Claude home
+#   CLAUDE_HOME=~/.claude,~/.claude-work — install to multiple (comma-separated)
+#   PENTEST_KIT_NO_DOCKER=1             — skip Docker image pull
+#   PENTEST_KIT_VERSION=v0.1.0          — install specific version (default: latest)
+#
+# Multi-profile: if multiple ~/.claude* dirs exist, the installer prompts
+# you to choose (or "all"). Override with CLAUDE_HOME to skip the prompt.
 
 set -uo pipefail
 
@@ -17,12 +22,83 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 REPO="nunenuh/pentest-kit"
-CLAUDE_DIR="$HOME/.claude"
-SKILL_DIR="$CLAUDE_DIR/skills/pentest-kit"
-AGENTS_DIR="$CLAUDE_DIR/agents"
 TMP_DIR=$(mktemp -d)
 VERSION="${PENTEST_KIT_VERSION:-latest}"
 NO_DOCKER="${PENTEST_KIT_NO_DOCKER:-0}"
+
+# ==========================================
+# Claude home detection — supports multi-profile setups
+# CLAUDE_HOME env var takes precedence. Otherwise auto-detect.
+# ==========================================
+detect_claude_homes() {
+    local homes=()
+    for d in "$HOME"/.claude "$HOME"/.claude-*; do
+        # Must be a directory and contain settings.json or settings.local.json
+        # (proof it's a real Claude home, not a random .claude-prefixed dir)
+        if [ -d "$d" ] && { [ -f "$d/settings.json" ] || [ -f "$d/settings.local.json" ] || [ -d "$d/skills" ]; }; then
+            homes+=("$d")
+        fi
+    done
+    # Fallback: if nothing matched but ~/.claude exists as a dir, include it
+    if [ ${#homes[@]} -eq 0 ] && [ -d "$HOME/.claude" ]; then
+        homes=("$HOME/.claude")
+    fi
+    printf '%s\n' "${homes[@]}"
+}
+
+pick_claude_homes() {
+    # If CLAUDE_HOME is set explicitly, use it (comma-separated for multiple).
+    if [ -n "${CLAUDE_HOME:-}" ]; then
+        IFS=',' read -ra SELECTED_HOMES <<< "$CLAUDE_HOME"
+        return
+    fi
+
+    mapfile -t ALL_HOMES < <(detect_claude_homes)
+
+    if [ ${#ALL_HOMES[@]} -eq 0 ]; then
+        echo -e "  ${RED}[ERROR]${NC} No Claude Code home directory found (~/.claude or ~/.claude-*)."
+        echo "  Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
+        echo "  Or set CLAUDE_HOME=/path/to/claude-home explicitly."
+        exit 1
+    fi
+
+    if [ ${#ALL_HOMES[@]} -eq 1 ]; then
+        SELECTED_HOMES=("${ALL_HOMES[0]}")
+        return
+    fi
+
+    # Multiple homes found — prompt user.
+    echo -e "  ${CYAN}Detected multiple Claude Code homes:${NC}"
+    for i in "${!ALL_HOMES[@]}"; do
+        echo -e "    $((i+1)). ${ALL_HOMES[$i]}"
+    done
+    echo -e "    $((${#ALL_HOMES[@]}+1)). All of the above"
+    echo ""
+
+    # If running non-interactively (piped), default to "all".
+    if [ ! -t 0 ]; then
+        echo -e "  ${YELLOW}[NON-INTERACTIVE]${NC} Installing to all detected homes"
+        SELECTED_HOMES=("${ALL_HOMES[@]}")
+        return
+    fi
+
+    read -rp "  Install to [1-$((${#ALL_HOMES[@]}+1))]: " choice
+    if [ "$choice" -eq "$((${#ALL_HOMES[@]}+1))" ] 2>/dev/null; then
+        SELECTED_HOMES=("${ALL_HOMES[@]}")
+    elif [ "$choice" -ge 1 ] 2>/dev/null && [ "$choice" -le "${#ALL_HOMES[@]}" ] 2>/dev/null; then
+        SELECTED_HOMES=("${ALL_HOMES[$((choice-1))]}")
+    else
+        echo -e "  ${RED}[ERROR]${NC} Invalid choice: $choice"
+        exit 1
+    fi
+}
+
+SELECTED_HOMES=()
+pick_claude_homes
+
+# For backwards compat, set CLAUDE_DIR to the first selected home.
+# install_to_home() handles the per-home install loop below.
+CLAUDE_DIR="${SELECTED_HOMES[0]}"
 
 cleanup() {
     rm -rf "$TMP_DIR"
@@ -40,12 +116,10 @@ echo ""
 # ==========================================
 echo -e "${BOLD}[1/5] Checking prerequisites...${NC}"
 
-if [ ! -d "$CLAUDE_DIR" ]; then
-    echo -e "  ${RED}[ERROR]${NC} ~/.claude/ not found. Is Claude Code installed?"
-    echo "  Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
-    exit 1
-fi
-echo -e "  ${GREEN}[OK]${NC} Claude Code detected"
+echo -e "  ${GREEN}[OK]${NC} Claude Code detected (${#SELECTED_HOMES[@]} home(s))"
+for h in "${SELECTED_HOMES[@]}"; do
+    echo -e "    → $h"
+done
 
 if ! command -v curl &>/dev/null; then
     echo -e "  ${RED}[ERROR]${NC} curl not found"
@@ -123,35 +197,60 @@ if [ ! -d "$SRC" ]; then
     exit 1
 fi
 
-# Backup existing
-if [ -d "$SKILL_DIR" ]; then
-    backup="$SKILL_DIR.backup.$(date +%s)"
-    mv "$SKILL_DIR" "$backup"
-    echo -e "  ${YELLOW}[BACKUP]${NC} Existing skill → $(basename $backup)"
-fi
+# Function: install skill + tools into a single Claude home.
+install_skill_to_home() {
+    local claude_home="$1"
+    local skill_dir="$claude_home/skills/pentest-kit"
 
-# Install skill
-mkdir -p "$SKILL_DIR"
+    echo -e "  ${CYAN}Installing to: $claude_home${NC}"
 
-if [ -d "$SRC/.claude/skills/pentest-kit" ]; then
-    cp -r "$SRC/.claude/skills/pentest-kit/"* "$SKILL_DIR/"
-    echo -e "  ${GREEN}[OK]${NC} Skill installed"
-else
-    echo -e "  ${RED}[ERROR]${NC} Skill files not found in archive"
-    exit 1
-fi
+    # Backup existing
+    if [ -d "$skill_dir" ]; then
+        backup="$skill_dir.backup.$(date +%s)"
+        mv "$skill_dir" "$backup"
+        echo -e "    ${YELLOW}[BACKUP]${NC} Existing skill → $(basename $backup)"
+    fi
 
-# Install tools into skill directory
-if [ -d "$SRC/tools" ]; then
-    mkdir -p "$SKILL_DIR/tools"
-    cp -r "$SRC/tools/wrappers" "$SKILL_DIR/tools/" 2>/dev/null
-    cp -r "$SRC/tools/addons" "$SKILL_DIR/tools/" 2>/dev/null
-    cp "$SRC/tools/REGISTRY.md" "$SKILL_DIR/tools/" 2>/dev/null
-    cp "$SRC/tools/PIPELINES.md" "$SKILL_DIR/tools/" 2>/dev/null
-    cp "$SRC/tools/preflight.sh" "$SKILL_DIR/tools/" 2>/dev/null
-    chmod +x "$SKILL_DIR/tools/preflight.sh" 2>/dev/null
-    echo -e "  ${GREEN}[OK]${NC} Tools installed"
-fi
+    # Install skill
+    mkdir -p "$skill_dir"
+
+    if [ -d "$SRC/.claude/skills/pentest-kit" ]; then
+        cp -r "$SRC/.claude/skills/pentest-kit/"* "$skill_dir/"
+        echo -e "    ${GREEN}[OK]${NC} Skill installed"
+    else
+        echo -e "    ${RED}[ERROR]${NC} Skill files not found in archive"
+        return 1
+    fi
+
+    # Install tools into skill directory
+    if [ -d "$SRC/tools" ]; then
+        mkdir -p "$skill_dir/tools"
+        cp -r "$SRC/tools/wrappers" "$skill_dir/tools/" 2>/dev/null
+        cp -r "$SRC/tools/addons" "$skill_dir/tools/" 2>/dev/null
+        cp "$SRC/tools/REGISTRY.md" "$skill_dir/tools/" 2>/dev/null
+        cp "$SRC/tools/PIPELINES.md" "$skill_dir/tools/" 2>/dev/null
+        cp "$SRC/tools/preflight.sh" "$skill_dir/tools/" 2>/dev/null
+        chmod +x "$skill_dir/tools/preflight.sh" 2>/dev/null
+        echo -e "    ${GREEN}[OK]${NC} Tools installed"
+    fi
+
+    # Save per-home config
+    cat > "$skill_dir/.pentest-kit-config" << CFGEOF
+{
+  "installed_at": "$(date -u '+%Y-%m-%dT%H:%M:%SZ')",
+  "version": "$VERSION",
+  "method": "remote",
+  "source": "https://github.com/$REPO",
+  "claude_home": "$claude_home"
+}
+CFGEOF
+}
+
+# Install skill to all selected homes.
+for home in "${SELECTED_HOMES[@]}"; do
+    install_skill_to_home "$home"
+done
+echo -e "  ${GREEN}[OK]${NC} Skill installed to ${#SELECTED_HOMES[@]} home(s)"
 
 # Install Docker working directory (~/.pentest-kit/)
 # This is where users run docker compose from, with targets/ and results/ mounts
@@ -260,23 +359,27 @@ else
     echo -e "  ${YELLOW}[SKIP]${NC} Unsupported OS/arch for CLI binary ($(uname -s)/$(uname -m))"
 fi
 
-# Install agents
-mkdir -p "$AGENTS_DIR"
-if [ -d "$SRC/.claude/agents" ]; then
-    for agent in "$SRC/.claude/agents/"*.md; do
-        name=$(basename "$agent")
-        dst="$AGENTS_DIR/$name"
+# Install agents to all selected homes.
+install_agents_to_home() {
+    local claude_home="$1"
+    local agents_dir="$claude_home/agents"
+    mkdir -p "$agents_dir"
+    if [ -d "$SRC/.claude/agents" ]; then
+        for agent in "$SRC/.claude/agents/"*.md; do
+            name=$(basename "$agent")
+            dst="$agents_dir/$name"
+            if [ -f "$dst" ] && ! grep -q "Pentest-Kit" "$dst" 2>/dev/null; then
+                dst="$agents_dir/pentest-kit-$name"
+            fi
+            cp "$agent" "$dst"
+        done
+    fi
+}
 
-        # Handle conflicts
-        if [ -f "$dst" ] && ! grep -q "Pentest-Kit" "$dst" 2>/dev/null; then
-            dst="$AGENTS_DIR/pentest-kit-$name"
-            echo -e "  ${YELLOW}[RENAME]${NC} $name exists → pentest-kit-$name"
-        fi
-
-        cp "$agent" "$dst"
-    done
-    echo -e "  ${GREEN}[OK]${NC} Agents installed"
-fi
+for home in "${SELECTED_HOMES[@]}"; do
+    install_agents_to_home "$home"
+done
+echo -e "  ${GREEN}[OK]${NC} Agents installed to ${#SELECTED_HOMES[@]} home(s)"
 
 # ==========================================
 # Step 4: Docker (optional)
@@ -306,17 +409,10 @@ fi
 echo ""
 echo -e "${BOLD}[5/5] Finalizing...${NC}"
 
-cat > "$SKILL_DIR/.pentest-kit-config" << EOF
-{
-  "installed_at": "$(date -u '+%Y-%m-%dT%H:%M:%SZ')",
-  "version": "$VERSION",
-  "method": "remote",
-  "source": "https://github.com/$REPO"
-}
-EOF
-
-file_count=$(find "$SKILL_DIR" -type f | wc -l)
-echo -e "  ${GREEN}[OK]${NC} Config saved ($file_count files installed)"
+# Count files in the first home's skill dir for the summary.
+SKILL_DIR="${SELECTED_HOMES[0]}/skills/pentest-kit"
+file_count=$(find "$SKILL_DIR" -type f 2>/dev/null | wc -l)
+echo -e "  ${GREEN}[OK]${NC} Finalized ($file_count files per home, ${#SELECTED_HOMES[@]} home(s))"
 
 # ==========================================
 # Summary
@@ -326,10 +422,13 @@ echo -e "${BOLD}${CYAN}==========================================${NC}"
 echo -e "${BOLD}${CYAN}  pentest-kit $VERSION installed${NC}"
 echo -e "${BOLD}${CYAN}==========================================${NC}"
 echo ""
-echo -e "  Skill:     ${GREEN}$SKILL_DIR${NC}"
-echo -e "  Agents:    ${GREEN}$AGENTS_DIR${NC}"
+for home in "${SELECTED_HOMES[@]}"; do
+    echo -e "  Claude:    ${GREEN}$home${NC}"
+    echo -e "    Skill:   ${GREEN}$home/skills/pentest-kit${NC}"
+    echo -e "    Agents:  ${GREEN}$home/agents${NC}"
+done
 echo -e "  Workspace: ${GREEN}$WORK_DIR${NC}"
-echo -e "  Files:     ${GREEN}$file_count${NC}"
+echo -e "  Files:     ${GREEN}$file_count per home${NC}"
 echo ""
 echo -e "  ${BOLD}Usage:${NC}"
 echo "    Open Claude Code in any directory and use:"
@@ -346,7 +445,10 @@ echo -e "  ${BOLD}Update:${NC}"
 echo "    curl -sSL https://get.nunenuh.me/pentest-kit | bash"
 echo ""
 echo -e "  ${BOLD}Uninstall:${NC}"
-echo "    rm -rf $SKILL_DIR $WORK_DIR"
-echo "    rm -f $AGENTS_DIR/orchestrator.md $AGENTS_DIR/executor.md"
-echo "    rm -f $AGENTS_DIR/pentest-kit-orchestrator.md $AGENTS_DIR/pentest-kit-executor.md"
+for home in "${SELECTED_HOMES[@]}"; do
+    echo "    rm -rf $home/skills/pentest-kit"
+    echo "    rm -f $home/agents/orchestrator.md $home/agents/executor.md"
+    echo "    rm -f $home/agents/pentest-kit-orchestrator.md $home/agents/pentest-kit-executor.md"
+done
+echo "    rm -rf $WORK_DIR"
 echo ""

--- a/install-remote.sh
+++ b/install-remote.sh
@@ -8,7 +8,8 @@
 #   CLAUDE_HOME=~/.claude,~/.claude-work — install to multiple (comma-separated)
 #   PENTEST_KIT_NO_DOCKER=1             — skip Docker image pull
 #   PENTEST_KIT_VERSION=v0.1.0          — install specific version (default: latest)
-#   PENTEST_KIT_VERSION=dev             — install from dev branch (latest, pre-release)
+#   PENTEST_KIT_VERSION=dev             — install from dev branch HEAD (source only)
+#   PENTEST_KIT_VERSION=dev-latest      — install latest dev pre-release (with CLI binary)
 #   PENTEST_KIT_VERSION=main            — install from main branch HEAD
 #
 # Multi-profile: if multiple ~/.claude* dirs exist, the installer prompts
@@ -140,11 +141,21 @@ echo ""
 echo -e "${BOLD}[2/5] Downloading pentest-kit...${NC}"
 
 if [ "$VERSION" = "latest" ]; then
-    # Get latest release tag
+    # Get latest stable release tag (from main)
     VERSION=$(curl -sSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
     if [ -z "$VERSION" ]; then
         echo -e "  ${YELLOW}[WARN]${NC} Could not determine latest version, using main branch"
         VERSION="main"
+    fi
+elif [ "$VERSION" = "dev-latest" ]; then
+    # Get latest pre-release tag (from dev branch, contains "-dev.")
+    VERSION=$(curl -sSL "https://api.github.com/repos/$REPO/releases?per_page=20" \
+        | python3 -c "import json,sys; tags=[r['tag_name'] for r in json.load(sys.stdin) if '-dev.' in r['tag_name']]; print(tags[0] if tags else '')" 2>/dev/null)
+    if [ -z "$VERSION" ]; then
+        echo -e "  ${YELLOW}[WARN]${NC} No dev pre-release found, falling back to dev branch HEAD"
+        VERSION="dev"
+    else
+        echo -e "  ${CYAN}[DEV]${NC} Latest dev release: $VERSION"
     fi
 fi
 


### PR DESCRIPTION
Closes #46.

## Summary

- `CLAUDE_HOME=~/.claude-work curl ... | bash` → install to specific profile
- `CLAUDE_HOME=~/.claude,~/.claude-work curl ... | bash` → install to multiple
- Auto-detects `~/.claude*` dirs, prompts if multiple found
- Non-interactive (piped) defaults to "all"
- CLI binary + Docker workspace remain shared, only skills/agents are per-home

## Test plan

- [ ] `bash -n install-remote.sh` — syntax valid
- [ ] Single home: `CLAUDE_HOME=/tmp/test-claude bash install-remote.sh` (after creating the dir)
- [ ] Multiple homes: `CLAUDE_HOME=/tmp/c1,/tmp/c2 bash install-remote.sh`
- [ ] Auto-detect: run without CLAUDE_HOME on a machine with multiple `~/.claude*`
- [ ] Backwards compat: single `~/.claude` → works exactly as before