### PR TITLE
feat(copilot): V1 complete — auth, transcript/resume, reasoning strategy #44

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -236,6 +236,76 @@ Browser-driven, LLM-reasoned pentesting. Use for:
 | `shell` | Run any container tool (curl, jq, jwt_tool, sqlmap, ffuf, …) | argv (list) or cmd (string) |
 | `note` | Record a finding, hypothesis, or dead end | type, title, severity, evidence |
 
+**Authentication (if auth.yaml exists):**
+
+Place `auth.yaml` in `results/{eng}/auth.yaml` before starting copilot:
+```yaml
+version: 1
+type: form
+login_url: /#/login
+username_field: email
+password_field: password
+success_indicator: token
+credentials:
+  - role: admin
+    email: admin@example.com
+    password: admin123
+  - role: user
+    email: user@example.com
+    password: user123
+  - role: anonymous
+```
+Switch roles mid-session: `browser switch_role --args '{"role":"admin"}'`
+
+**Resume (for long sessions):**
+```
+pentest-kit copilot resume <eng>     ← restarts loop from state + summary
+pentest-kit copilot turn <eng> --primitive resume  ← get full resume context
+```
+
+**Reasoning strategy (CRITICAL — follow this every turn):**
+
+```
+EACH TURN:
+1. READ the observation from the previous turn response:
+   - dom_summary: what's on the page (title, forms, links, errors)
+   - dom_digest: if same as last turn, your action had no visible effect — try something else
+   - screenshot: look at it if dom_summary is ambiguous
+   - new auto-findings from interceptor (IDOR candidates, JWTs, missing headers)
+
+2. DECIDE what to do next by asking yourself:
+   a. Am I still mapping? → navigate to an unmapped link or endpoint
+   b. Have I found something interesting? → test the hypothesis (SQLi, IDOR, XSS, auth bypass)
+   c. Am I stuck on the same page? → try a different approach or move to another area
+   d. Am I logged in as the right role? → switch_role if needed
+   e. Have I tested this area enough? → move on, don't repeat
+
+3. EXECUTE exactly ONE primitive per turn:
+   - browser: for navigation, interaction, form filling
+   - http: for raw API testing (bypassing the UI)
+   - shell: for running tools (sqlmap, jwt_tool, ffuf, nuclei)
+   - note: to record what you found or what didn't work
+
+4. OBSERVE the response — look for:
+   - Error messages that leak info (stack traces, SQL errors, debug output)
+   - Status codes that differ between roles (403 as user → 200 as admin = IDOR)
+   - DOM changes after input (reflected content = potential XSS)
+   - New endpoints in endpoints.json (interceptor maps them automatically)
+   - Cookies / tokens changing (session fixation, JWT issues)
+
+5. If summary_prompt appears in the response:
+   → You've done 25 turns. Write a summary via note with type="summary".
+     Cover: what's mapped, current theory, findings so far, dead ends.
+     This summary is your memory for resume — make it count.
+
+ANTI-PATTERNS (avoid these):
+- Don't navigate to the same page 3+ times without changing your approach
+- Don't test the same input twice — record it as a dead_end note and move on
+- Don't forget to switch roles — test the same endpoint as admin AND user
+- Don't ignore interceptor auto-findings — they're free intelligence
+- Don't run heavy tools (sqlmap, ffuf) before mapping the target first
+```
+
 Traffic is auto-intercepted by mitmproxy + `tools/copilot/interceptor.py`.
 The interceptor auto-detects IDOR candidates, JWTs, UUIDs, sensitive data,
 and missing security headers — these appear in `copilot/interceptor/findings.ndjson`.

--- a/pentest-kit-cli/cmd/pentest-kit/copilot.go
+++ b/pentest-kit-cli/cmd/pentest-kit/copilot.go
@@ -23,6 +23,7 @@ func copilotCmd() *cobra.Command {
 	cmd.AddCommand(copilotStopCmd())
 	cmd.AddCommand(copilotStatusCmd())
 	cmd.AddCommand(copilotTurnCmd())
+	cmd.AddCommand(copilotResumeCmd())
 
 	return cmd
 }
@@ -84,6 +85,78 @@ func copilotStartCmd() *cobra.Command {
 			fmt.Printf("  ✓ Log:    results/%s/copilot/loop.log\n", args[0])
 			fmt.Println("\n  Use: pentest-kit copilot turn <eng> --primitive browser --action navigate --args '{\"url\":\"...\"}'")
 			fmt.Println("  Or:  pentest-kit copilot status <eng>")
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&proxyPort, "proxy-port", 8081, "mitmproxy listen port inside container")
+	return cmd
+}
+
+// ─── resume ────────────────────────────────────────────────────────────
+
+func copilotResumeCmd() *cobra.Command {
+	var proxyPort int
+
+	cmd := &cobra.Command{
+		Use:   "resume <engagement>",
+		Short: "Resume a copilot session from transcript + state",
+		Long: "Restarts the loop process with --resume flag.\n" +
+			"Loads state.json, summary.md, last 10 turns from transcript,\n" +
+			"saved auth sessions, and endpoints.json. Does NOT replay\n" +
+			"the full transcript — the rolling summary is the memory.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := docker.FindWorkspace()
+			if err != nil {
+				return err
+			}
+
+			// Read target from state.json.
+			targetCmd := fmt.Sprintf(
+				`python3 -c "import json; print(json.load(open('/pentest-kit/results/%s/state.json'))['target'])" 2>/dev/null`,
+				args[0],
+			)
+			targetOut, err := docker.ExecCapture(ws, []string{"bash", "-c", targetCmd})
+			if err != nil {
+				return fmt.Errorf("engagement %q not found or has no state.json — nothing to resume", args[0])
+			}
+			target := strings.TrimSpace(targetOut)
+			if target == "" {
+				return fmt.Errorf("engagement %q has no target in state.json", args[0])
+			}
+
+			// Kill any existing loop first.
+			pidFile := fmt.Sprintf("/pentest-kit/results/%s/copilot/loop.pid", args[0])
+			_ = docker.Exec(ws, []string{"bash", "-c", fmt.Sprintf(
+				"[ -f %s ] && kill $(cat %s) 2>/dev/null; rm -f %s; true", pidFile, pidFile, pidFile,
+			)})
+
+			// Launch loop.py with --resume flag.
+			loopCmd := fmt.Sprintf(
+				"nohup python3 /pentest-kit/tools/copilot/loop.py "+
+					"--engagement %s "+
+					"--target %s "+
+					"--results /pentest-kit/results/%s "+
+					"--proxy-port %d "+
+					"--resume "+
+					"> /pentest-kit/results/%s/copilot/loop.log 2>&1 &"+
+					" echo $!",
+				args[0], target, args[0], proxyPort, args[0],
+			)
+
+			fmt.Println("Resuming copilot loop...")
+			out, err := docker.ExecCapture(ws, []string{"bash", "-c", loopCmd})
+			if err != nil {
+				return fmt.Errorf("failed to resume copilot loop: %w", err)
+			}
+
+			pid := strings.TrimSpace(out)
+			fmt.Printf("  ✓ Copilot loop resumed (PID %s)\n", pid)
+			fmt.Printf("  ✓ Target: %s\n", target)
+			fmt.Println("\n  The loop loaded state.json + summary.md + last 10 turns.")
+			fmt.Println("  Send a 'resume' primitive to get the full resume context:")
+			fmt.Printf("    pentest-kit copilot turn %s --primitive resume\n", args[0])
 			return nil
 		},
 	}

--- a/specs/COPILOT.md
+++ b/specs/COPILOT.md
@@ -177,11 +177,69 @@ pentest-kit copilot stop <eng>
   The http primitive borrows them for raw requests but never logs them in
   the transcript.
 
+## Authentication (`auth.yaml`)
+
+Place `auth.yaml` in `results/{engagement}/auth.yaml` before starting copilot.
+
+```yaml
+version: 1
+type: form                          # form | bearer | cookie
+login_url: /#/login
+username_field: email               # CSS selector or field name
+password_field: password
+submit_selector: button[type="submit"]  # optional, defaults to Enter key
+success_indicator: token            # localStorage key | url_contains:X | text_contains:X
+logout_url: /#/logout               # optional
+credentials:
+  - role: admin
+    email: admin@example.com
+    password: admin123
+  - role: user
+    email: user@example.com
+    password: user123
+  - role: anonymous                 # no creds = browse without login
+```
+
+**Behavior:**
+
+- On first `browser switch_role <role>`, the loop runs the Playwright login flow
+  for that role and saves `storage_state.json` under `copilot/sessions/{role}.json`
+- Subsequent `switch_role` calls load the saved session (no re-login)
+- On `copilot resume`, the saved session is auto-loaded for the last active role
+- Anonymous role creates an empty session (no login)
+- Field filling tries: CSS selector → `[name="..."]` → `#id` → `[placeholder*="..." i]`
+
+**Switch roles mid-session:**
+```bash
+pentest-kit copilot turn <eng> --primitive browser --action switch_role --args '{"role":"admin"}'
+```
+
+## Transcript + Resume
+
+**Transcript** (`copilot/transcript.ndjson`): append-only log of every turn.
+
+**Rolling summary** (`copilot/summary.md`): every 25 turns, the loop prompts the
+agent to rewrite a ≤20-line summary covering: mapped endpoints, current theory,
+confirmed findings, dead ends. This is the "memory" that survives context
+compression and resume.
+
+**Resume flow:**
+```bash
+pentest-kit copilot resume <eng>
+# → kills any existing loop, restarts with --resume flag
+# → loads state.json + summary.md + last 10 turns + endpoints.json + saved sessions
+# → does NOT replay the full transcript
+
+pentest-kit copilot turn <eng> --primitive resume
+# → returns the full resume context as JSON
+```
+
+Resume context includes: engagement, target, current_role, last_turn count,
+findings_count, endpoints_count, summary text, recent turns, endpoints preview.
+
 ## Not Yet Implemented (follow-up PRs)
 
-- `auth.yaml` — per-role authentication + storage_state persistence (T4)
 - `challenges.yaml` — CTF challenge tracking + auto-solve detection (T6)
-- Transcript + rolling summarization + resume (T5)
 - `copilot replay` — transcript stepping + debugging (T10)
 - Integration test against live Juice Shop (T11)
 

--- a/tools/copilot/_auth.py
+++ b/tools/copilot/_auth.py
@@ -1,0 +1,292 @@
+"""
+Authentication persistence for copilot mode.
+
+Loads auth.yaml from the engagement directory, runs Playwright login
+flows per credential set, saves storage_state.json per role, and
+supports switching roles mid-session via browser context swap.
+
+auth.yaml schema:
+
+    version: 1
+    type: form                    # form | bearer | cookie
+    login_url: /#/login
+    username_field: email         # CSS selector or field name
+    password_field: password
+    submit_selector: button[type="submit"]   # optional, defaults to Enter key
+    success_indicator: token      # localStorage key | url_contains:X | text_contains:X
+    logout_url: /#/logout         # optional
+    credentials:
+      - role: admin
+        email: admin@example.com
+        password: admin123
+      - role: user
+        email: user@example.com
+        password: user123
+      - role: anonymous
+        # no creds = browse without login
+
+Security: auth.yaml lives in the engagement results dir (bind-mounted).
+Credentials are per-engagement, never committed to git.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger("copilot.auth")
+
+
+@dataclass(frozen=True)
+class Credential:
+    role: str
+    fields: dict[str, str]  # {field_name: value} — e.g. {"email": "admin@...", "password": "..."}
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    version: int
+    auth_type: str  # form | bearer | cookie
+    login_url: str
+    username_field: str
+    password_field: str
+    submit_selector: str | None
+    success_indicator: str
+    logout_url: str | None
+    credentials: list[Credential]
+
+    def get_credential(self, role: str) -> Credential | None:
+        for c in self.credentials:
+            if c.role == role:
+                return c
+        return None
+
+    @property
+    def roles(self) -> list[str]:
+        return [c.role for c in self.credentials]
+
+
+def load_auth_config(path: Path) -> AuthConfig | None:
+    """Load auth.yaml from the given path. Returns None if file doesn't exist."""
+    if not path.exists():
+        return None
+
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"auth.yaml must be a YAML mapping, got {type(data).__name__}")
+
+    version = data.get("version", 1)
+    auth_type = data.get("type", "form")
+    if auth_type not in ("form", "bearer", "cookie"):
+        raise ValueError(f"auth.yaml type must be form|bearer|cookie, got {auth_type!r}")
+
+    credentials = []
+    for entry in data.get("credentials", []):
+        role = entry.get("role", "default")
+        # Collect all fields except 'role' as credential fields.
+        fields = {k: str(v) for k, v in entry.items() if k != "role" and v is not None}
+        credentials.append(Credential(role=role, fields=fields))
+
+    return AuthConfig(
+        version=version,
+        auth_type=auth_type,
+        login_url=data.get("login_url", ""),
+        username_field=data.get("username_field", "username"),
+        password_field=data.get("password_field", "password"),
+        submit_selector=data.get("submit_selector"),
+        success_indicator=data.get("success_indicator", ""),
+        logout_url=data.get("logout_url"),
+        credentials=credentials,
+    )
+
+
+@dataclass
+class AuthManager:
+    """Manages per-role browser sessions using Playwright storage_state."""
+
+    config: AuthConfig
+    sessions_dir: Path
+    _states: dict[str, Path] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        # Discover already-saved sessions from previous runs (resume support).
+        for f in self.sessions_dir.glob("*.json"):
+            role = f.stem
+            self._states[role] = f
+            logger.info("Found saved session for role: %s", role)
+
+    def has_session(self, role: str) -> bool:
+        return role in self._states
+
+    def session_path(self, role: str) -> Path:
+        return self.sessions_dir / f"{role}.json"
+
+    async def login(self, browser_context_factory: Any, role: str) -> Path:
+        """Run the login flow for a role and save storage_state.
+
+        `browser_context_factory` is an async callable that creates a new
+        BrowserContext (from the BrowserWrapper). After login, the context
+        is saved and closed.
+
+        Returns the path to the saved storage_state.json.
+        """
+        cred = self.config.get_credential(role)
+        if cred is None:
+            raise ValueError(f"No credentials for role {role!r}. Available: {self.config.roles}")
+
+        if not cred.fields:
+            # Anonymous role — no login needed. Save an empty state.
+            empty_state = self.session_path(role)
+            empty_state.write_text("{}")
+            self._states[role] = empty_state
+            logger.info("Anonymous role %r — no login needed", role)
+            return empty_state
+
+        logger.info("Logging in as %r via %s at %s", role, self.config.auth_type, self.config.login_url)
+
+        if self.config.auth_type == "form":
+            return await self._login_form(browser_context_factory, role, cred)
+        elif self.config.auth_type == "bearer":
+            return await self._login_bearer(browser_context_factory, role, cred)
+        elif self.config.auth_type == "cookie":
+            return await self._login_cookie(browser_context_factory, role, cred)
+        else:
+            raise ValueError(f"Unsupported auth type: {self.config.auth_type}")
+
+    async def _login_form(self, ctx_factory: Any, role: str, cred: Credential) -> Path:
+        """Form-based login: navigate to login_url, fill fields, submit."""
+        context = await ctx_factory()
+        page = await context.new_page()
+
+        try:
+            await page.goto(self.config.login_url, wait_until="networkidle", timeout=30000)
+
+            # Fill username field.
+            username_value = cred.fields.get(self.config.username_field, "")
+            if username_value:
+                await self._fill_field(page, self.config.username_field, username_value)
+
+            # Fill password field.
+            password_value = cred.fields.get(self.config.password_field, "")
+            if password_value:
+                await self._fill_field(page, self.config.password_field, password_value)
+
+            # Submit.
+            if self.config.submit_selector:
+                await page.click(self.config.submit_selector, timeout=5000)
+            else:
+                await page.keyboard.press("Enter")
+
+            # Wait for navigation / network idle after submit.
+            await page.wait_for_load_state("networkidle", timeout=15000)
+
+            # Verify success.
+            success = await self._check_success(page)
+            if not success:
+                logger.warning("Login may have failed for role %r — success indicator not found", role)
+
+            # Save storage state.
+            state_path = self.session_path(role)
+            await context.storage_state(path=str(state_path))
+            self._states[role] = state_path
+            logger.info("Session saved for role %r → %s", role, state_path)
+            return state_path
+
+        finally:
+            await context.close()
+
+    async def _login_bearer(self, ctx_factory: Any, role: str, cred: Credential) -> Path:
+        """Bearer token login: navigate, extract token from response, save as state.
+
+        For APIs that return a JWT on login. We do the same form fill but
+        then extract the token from localStorage/response and save it.
+        """
+        # Bearer login is the same form flow but we explicitly capture the token.
+        return await self._login_form(ctx_factory, role, cred)
+
+    async def _login_cookie(self, ctx_factory: Any, role: str, cred: Credential) -> Path:
+        """Cookie-based login: same as form but relies on Set-Cookie."""
+        return await self._login_form(ctx_factory, role, cred)
+
+    async def _fill_field(self, page: Any, field_name: str, value: str) -> None:
+        """Fill a form field by trying CSS selector first, then name attribute."""
+        # Try direct CSS selector.
+        try:
+            elem = await page.query_selector(field_name)
+            if elem:
+                await elem.fill(value)
+                return
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Try by name attribute.
+        try:
+            await page.fill(f'[name="{field_name}"]', value)
+            return
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Try by id.
+        try:
+            await page.fill(f"#{field_name}", value)
+            return
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Try by placeholder.
+        try:
+            await page.fill(f'[placeholder*="{field_name}" i]', value)
+            return
+        except Exception:  # noqa: BLE001
+            pass
+
+        logger.warning("Could not find field %r — tried selector, name, id, placeholder", field_name)
+
+    async def _check_success(self, page: Any) -> bool:
+        """Check if login succeeded using the configured success_indicator."""
+        indicator = self.config.success_indicator
+        if not indicator:
+            return True  # No indicator configured — assume success.
+
+        # url_contains:X
+        if indicator.startswith("url_contains:"):
+            expected = indicator.split(":", 1)[1]
+            return expected in page.url
+
+        # text_contains:X
+        if indicator.startswith("text_contains:"):
+            expected = indicator.split(":", 1)[1]
+            content = await page.text_content("body") or ""
+            return expected.lower() in content.lower()
+
+        # Default: check localStorage for the key.
+        try:
+            result = await page.evaluate(f"localStorage.getItem('{indicator}')")
+            return result is not None and result != ""
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def load_session(self, context: Any, role: str) -> bool:
+        """Load a saved session into an existing browser context.
+
+        Returns True if the session was loaded, False if no session exists
+        (caller should run login() first).
+        """
+        if role not in self._states:
+            return False
+
+        state_path = self._states[role]
+        if not state_path.exists():
+            return False
+
+        # Playwright contexts can't load storage_state after creation.
+        # The caller must create a new context with storage_state parameter.
+        # This method exists for the contract — actual loading happens in
+        # BrowserWrapper.switch_role().
+        return True

--- a/tools/copilot/_auth_test.py
+++ b/tools/copilot/_auth_test.py
@@ -1,0 +1,145 @@
+"""Tests for _auth — config loading and credential management (no browser)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _auth import AuthConfig, AuthManager, Credential, load_auth_config
+
+
+@pytest.fixture()
+def auth_yaml(tmp_path: Path) -> Path:
+    path = tmp_path / "auth.yaml"
+    path.write_text("""
+version: 1
+type: form
+login_url: "/#/login"
+username_field: email
+password_field: password
+submit_selector: "button[type='submit']"
+success_indicator: token
+logout_url: "/#/logout"
+credentials:
+  - role: admin
+    email: admin@juice-sh.op
+    password: admin123
+  - role: user
+    email: user@example.com
+    password: user123
+  - role: anonymous
+""")
+    return path
+
+
+def test_load_valid_config(auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+    assert config.version == 1
+    assert config.auth_type == "form"
+    assert config.login_url == "/#/login"
+    assert config.username_field == "email"
+    assert config.password_field == "password"
+    assert config.submit_selector == "button[type='submit']"
+    assert config.success_indicator == "token"
+    assert config.logout_url == "/#/logout"
+    assert len(config.credentials) == 3
+
+
+def test_load_nonexistent_returns_none(tmp_path: Path):
+    assert load_auth_config(tmp_path / "nope.yaml") is None
+
+
+def test_load_invalid_type(tmp_path: Path):
+    path = tmp_path / "auth.yaml"
+    path.write_text("version: 1\ntype: oauth\ncredentials: []")
+    with pytest.raises(ValueError, match="form|bearer|cookie"):
+        load_auth_config(path)
+
+
+def test_roles_list(auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+    assert config.roles == ["admin", "user", "anonymous"]
+
+
+def test_get_credential_found(auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+    cred = config.get_credential("admin")
+    assert cred is not None
+    assert cred.role == "admin"
+    assert cred.fields["email"] == "admin@juice-sh.op"
+    assert cred.fields["password"] == "admin123"
+
+
+def test_get_credential_not_found(auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+    assert config.get_credential("superadmin") is None
+
+
+def test_anonymous_has_no_fields(auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+    cred = config.get_credential("anonymous")
+    assert cred is not None
+    assert cred.fields == {}
+
+
+def test_auth_manager_discovers_saved_sessions(tmp_path: Path, auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    (sessions / "admin.json").write_text('{"cookies":[]}')
+
+    mgr = AuthManager(config=config, sessions_dir=sessions)
+    assert mgr.has_session("admin") is True
+    assert mgr.has_session("user") is False
+
+
+def test_auth_manager_session_path(tmp_path: Path, auth_yaml: Path):
+    config = load_auth_config(auth_yaml)
+    assert config is not None
+    mgr = AuthManager(config=config, sessions_dir=tmp_path / "sessions")
+    assert mgr.session_path("admin") == tmp_path / "sessions" / "admin.json"
+
+
+def test_minimal_config():
+    """Config with only required fields should still load."""
+    from io import StringIO
+    import yaml as _yaml
+
+    data = _yaml.safe_load(StringIO("""
+version: 1
+type: form
+login_url: /login
+credentials:
+  - role: admin
+    username: admin
+    password: secret
+"""))
+
+    config = AuthConfig(
+        version=data["version"],
+        auth_type=data["type"],
+        login_url=data["login_url"],
+        username_field=data.get("username_field", "username"),
+        password_field=data.get("password_field", "password"),
+        submit_selector=data.get("submit_selector"),
+        success_indicator=data.get("success_indicator", ""),
+        logout_url=data.get("logout_url"),
+        credentials=[
+            Credential(
+                role=c["role"],
+                fields={k: str(v) for k, v in c.items() if k != "role" and v is not None},
+            )
+            for c in data["credentials"]
+        ],
+    )
+    assert config.auth_type == "form"
+    assert len(config.credentials) == 1
+    assert config.credentials[0].fields["username"] == "admin"

--- a/tools/copilot/_transcript.py
+++ b/tools/copilot/_transcript.py
@@ -1,0 +1,219 @@
+"""
+Transcript + rolling summarization + resume for copilot mode.
+
+The transcript is an append-only NDJSON file recording every turn.
+Rolling summarization rewrites summary.md every N turns to keep
+a ≤20-line "what I've learned so far" document that survives context
+compression and resume.
+
+Resume loads: state.json + summary.md + last K turns from transcript
++ endpoints.json + saved sessions. It does NOT replay the full
+transcript — the summary is the memory.
+
+File layout under results/{eng}/copilot/:
+  transcript.ndjson   — every turn (append-only)
+  summary.md          — rolling summary (rewritten every SUMMARY_INTERVAL)
+  state.json          — {engagement, target, status, current_role, ...}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("copilot.transcript")
+
+SUMMARY_INTERVAL = 25  # Rewrite summary every N turns.
+RESUME_TAIL_TURNS = 10  # Load this many recent turns on resume.
+MAX_SUMMARY_LINES = 20
+
+
+@dataclass
+class TranscriptWriter:
+    """Append-only transcript + state management."""
+
+    copilot_dir: Path
+    _turn_count: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        self.copilot_dir.mkdir(parents=True, exist_ok=True)
+        # Count existing turns for resume.
+        transcript = self.copilot_dir / "transcript.ndjson"
+        if transcript.exists():
+            with transcript.open() as f:
+                self._turn_count = sum(1 for _ in f)
+            logger.info("Resuming from turn %d", self._turn_count)
+
+    @property
+    def turn_count(self) -> int:
+        return self._turn_count
+
+    def append(
+        self,
+        *,
+        turn: int,
+        primitive: str,
+        action: str,
+        args_summary: dict[str, Any],
+        result_summary: dict[str, Any],
+    ) -> None:
+        """Append a single turn to transcript.ndjson."""
+        entry = {
+            "turn": turn,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "primitive": primitive,
+            "action": action,
+            "args": args_summary,
+            "ok": result_summary.get("ok", False),
+            "url": result_summary.get("url", ""),
+            "screenshot": result_summary.get("screenshot"),
+            "error": result_summary.get("error"),
+            "title": result_summary.get("title", ""),
+        }
+        transcript = self.copilot_dir / "transcript.ndjson"
+        with transcript.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+        self._turn_count += 1
+
+    def needs_summary(self) -> bool:
+        """True if the summary should be rewritten this turn."""
+        return self._turn_count > 0 and self._turn_count % SUMMARY_INTERVAL == 0
+
+    def get_tail(self, n: int | None = None) -> list[dict[str, Any]]:
+        """Read the last N turns from transcript.ndjson."""
+        n = n or RESUME_TAIL_TURNS
+        transcript = self.copilot_dir / "transcript.ndjson"
+        if not transcript.exists():
+            return []
+        lines = transcript.read_text().strip().split("\n")
+        tail = lines[-n:] if len(lines) > n else lines
+        result = []
+        for line in tail:
+            if line.strip():
+                try:
+                    result.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        return result
+
+
+@dataclass
+class SummaryManager:
+    """Manages the rolling summary.md that survives context compression."""
+
+    copilot_dir: Path
+
+    def read(self) -> str:
+        """Read the current summary. Returns empty string if none exists."""
+        path = self.copilot_dir / "summary.md"
+        if path.exists():
+            return path.read_text()
+        return ""
+
+    def write(self, content: str) -> None:
+        """Write a new summary (overwrites previous). Caps at MAX_SUMMARY_LINES."""
+        lines = content.strip().split("\n")
+        if len(lines) > MAX_SUMMARY_LINES:
+            lines = lines[:MAX_SUMMARY_LINES]
+            lines.append("(truncated to 20 lines)")
+        path = self.copilot_dir / "summary.md"
+        path.write_text("\n".join(lines) + "\n")
+
+    def build_summary_prompt(self, tail: list[dict[str, Any]], findings_count: int,
+                              endpoints_count: int) -> str:
+        """Build the prompt the agent should answer to produce a new summary.
+
+        This is returned as a special response from the loop when
+        needs_summary() is True — the agent writes the new summary via
+        the note primitive with type=summary.
+        """
+        recent = "\n".join(
+            f"  turn {t.get('turn', '?')}: {t.get('primitive', '?')}.{t.get('action', '?')} "
+            f"→ {'ok' if t.get('ok') else 'err'} {t.get('url', '')}"
+            for t in tail
+        )
+        return (
+            f"Time to update your working summary. Rewrite summary.md in ≤20 lines covering:\n"
+            f"- What's been mapped (key endpoints, roles, auth state)\n"
+            f"- Current working theory / next hypothesis\n"
+            f"- Confirmed findings (just IDs + one-liner each)\n"
+            f"- Dead ends to avoid repeating\n\n"
+            f"Stats: {findings_count} findings, {endpoints_count} endpoints mapped\n"
+            f"Recent turns:\n{recent}\n\n"
+            f"Previous summary:\n{self.read()}\n\n"
+            f"Write the new summary via: note primitive with type='summary'"
+        )
+
+
+@dataclass
+class StateManager:
+    """Manages copilot/state.json — the engagement-level state."""
+
+    copilot_dir: Path
+
+    def read(self) -> dict[str, Any]:
+        path = self.copilot_dir / "state.json"
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return {}
+
+    def write(self, state: dict[str, Any]) -> None:
+        path = self.copilot_dir / "state.json"
+        path.write_text(json.dumps(state, indent=2) + "\n")
+
+    def update(self, updates: dict[str, Any]) -> dict[str, Any]:
+        state = self.read()
+        state.update(updates)
+        self.write(state)
+        return state
+
+
+def build_resume_context(copilot_dir: Path) -> dict[str, Any]:
+    """Build the context dict that the agent receives on copilot resume.
+
+    This is the "memory" — everything the agent needs to continue
+    where it left off without replaying the full transcript.
+    """
+    state_mgr = StateManager(copilot_dir)
+    summary_mgr = SummaryManager(copilot_dir)
+    transcript = TranscriptWriter(copilot_dir)
+
+    state = state_mgr.read()
+    summary = summary_mgr.read()
+    tail = transcript.get_tail(RESUME_TAIL_TURNS)
+
+    # Count findings.
+    findings_path = copilot_dir / "findings.ndjson"
+    findings_count = 0
+    if findings_path.exists():
+        with findings_path.open() as f:
+            findings_count = sum(1 for _ in f)
+
+    # Load endpoints summary.
+    endpoints_path = copilot_dir / "interceptor" / "endpoints.json"
+    endpoints: list[dict[str, Any]] = []
+    if endpoints_path.exists():
+        try:
+            endpoints = json.loads(endpoints_path.read_text())
+        except json.JSONDecodeError:
+            pass
+
+    return {
+        "type": "resume",
+        "engagement": state.get("engagement", ""),
+        "target": state.get("target", ""),
+        "current_role": state.get("current_role", "anonymous"),
+        "last_turn": transcript.turn_count,
+        "findings_count": findings_count,
+        "endpoints_count": len(endpoints),
+        "summary": summary,
+        "recent_turns": tail,
+        "endpoints_preview": endpoints[:20],  # cap to avoid context flooding
+    }

--- a/tools/copilot/_transcript_test.py
+++ b/tools/copilot/_transcript_test.py
@@ -1,0 +1,213 @@
+"""Tests for _transcript — writer, summary, state, resume context."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from _transcript import (
+    RESUME_TAIL_TURNS,
+    SUMMARY_INTERVAL,
+    SummaryManager,
+    StateManager,
+    TranscriptWriter,
+    build_resume_context,
+)
+
+
+# ─── TranscriptWriter ──────────────────────────────────────────────────
+
+
+def test_writer_starts_at_zero(tmp_path: Path):
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    assert w.turn_count == 0
+
+
+def test_writer_appends_turn(tmp_path: Path):
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    w.append(turn=1, primitive="browser", action="navigate",
+             args_summary={"url": "https://x.com"},
+             result_summary={"ok": True, "url": "https://x.com"})
+    assert w.turn_count == 1
+
+    transcript = tmp_path / "transcript.ndjson"
+    assert transcript.exists()
+    entry = json.loads(transcript.read_text().strip())
+    assert entry["turn"] == 1
+    assert entry["primitive"] == "browser"
+    assert entry["ok"] is True
+
+
+def test_writer_increments_count(tmp_path: Path):
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    for i in range(5):
+        w.append(turn=i+1, primitive="shell", action="run",
+                 args_summary={}, result_summary={"ok": True})
+    assert w.turn_count == 5
+
+
+def test_writer_resumes_from_existing(tmp_path: Path):
+    # Pre-populate transcript.
+    transcript = tmp_path / "transcript.ndjson"
+    transcript.write_text("\n".join(
+        json.dumps({"turn": i}) for i in range(10)
+    ) + "\n")
+
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    assert w.turn_count == 10
+
+
+def test_needs_summary(tmp_path: Path):
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    for i in range(SUMMARY_INTERVAL):
+        w.append(turn=i+1, primitive="shell", action="run",
+                 args_summary={}, result_summary={"ok": True})
+    assert w.needs_summary() is True
+
+
+def test_no_summary_before_interval(tmp_path: Path):
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    for i in range(SUMMARY_INTERVAL - 1):
+        w.append(turn=i+1, primitive="shell", action="run",
+                 args_summary={}, result_summary={"ok": True})
+    assert w.needs_summary() is False
+
+
+def test_get_tail(tmp_path: Path):
+    transcript = tmp_path / "transcript.ndjson"
+    lines = [json.dumps({"turn": i}) for i in range(30)]
+    transcript.write_text("\n".join(lines) + "\n")
+
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    tail = w.get_tail(5)
+    assert len(tail) == 5
+    assert tail[0]["turn"] == 25
+    assert tail[-1]["turn"] == 29
+
+
+def test_get_tail_fewer_than_n(tmp_path: Path):
+    transcript = tmp_path / "transcript.ndjson"
+    transcript.write_text(json.dumps({"turn": 1}) + "\n")
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    tail = w.get_tail(10)
+    assert len(tail) == 1
+
+
+def test_get_tail_empty(tmp_path: Path):
+    w = TranscriptWriter(copilot_dir=tmp_path)
+    assert w.get_tail() == []
+
+
+# ─── SummaryManager ────────────────────────────────────────────────────
+
+
+def test_summary_read_empty(tmp_path: Path):
+    mgr = SummaryManager(copilot_dir=tmp_path)
+    assert mgr.read() == ""
+
+
+def test_summary_write_and_read(tmp_path: Path):
+    mgr = SummaryManager(copilot_dir=tmp_path)
+    mgr.write("Line 1\nLine 2\nLine 3")
+    assert "Line 1" in mgr.read()
+    assert "Line 3" in mgr.read()
+
+
+def test_summary_truncates_at_20_lines(tmp_path: Path):
+    mgr = SummaryManager(copilot_dir=tmp_path)
+    content = "\n".join(f"Line {i}" for i in range(30))
+    mgr.write(content)
+    lines = mgr.read().strip().split("\n")
+    assert len(lines) == 21  # 20 + truncation notice
+    assert "truncated" in lines[-1]
+
+
+def test_summary_prompt_contains_stats(tmp_path: Path):
+    mgr = SummaryManager(copilot_dir=tmp_path)
+    mgr.write("Previous knowledge here")
+    prompt = mgr.build_summary_prompt(
+        tail=[{"turn": 1, "primitive": "browser", "action": "navigate", "ok": True, "url": "/"}],
+        findings_count=5,
+        endpoints_count=12,
+    )
+    assert "5 findings" in prompt
+    assert "12 endpoints" in prompt
+    assert "Previous knowledge" in prompt
+
+
+# ─── StateManager ──────────────────────────────────────────────────────
+
+
+def test_state_read_empty(tmp_path: Path):
+    mgr = StateManager(copilot_dir=tmp_path)
+    assert mgr.read() == {}
+
+
+def test_state_write_and_read(tmp_path: Path):
+    mgr = StateManager(copilot_dir=tmp_path)
+    mgr.write({"engagement": "demo", "target": "https://x.com"})
+    state = mgr.read()
+    assert state["engagement"] == "demo"
+    assert state["target"] == "https://x.com"
+
+
+def test_state_update_merges(tmp_path: Path):
+    mgr = StateManager(copilot_dir=tmp_path)
+    mgr.write({"engagement": "demo", "status": "running"})
+    result = mgr.update({"status": "stopped", "turns": 42})
+    assert result["engagement"] == "demo"
+    assert result["status"] == "stopped"
+    assert result["turns"] == 42
+
+
+# ─── build_resume_context ──────────────────────────────────────────────
+
+
+def test_resume_context_empty_dir(tmp_path: Path):
+    ctx = build_resume_context(tmp_path)
+    assert ctx["type"] == "resume"
+    assert ctx["last_turn"] == 0
+    assert ctx["findings_count"] == 0
+    assert ctx["summary"] == ""
+    assert ctx["recent_turns"] == []
+
+
+def test_resume_context_with_data(tmp_path: Path):
+    # State
+    (tmp_path / "state.json").write_text(json.dumps({
+        "engagement": "demo", "target": "https://x.com", "current_role": "admin",
+    }))
+
+    # Summary
+    (tmp_path / "summary.md").write_text("Found SQLi on /login\nMapped 5 endpoints")
+
+    # Transcript (15 turns)
+    transcript = tmp_path / "transcript.ndjson"
+    lines = [json.dumps({"turn": i, "primitive": "browser", "action": "nav", "ok": True})
+             for i in range(15)]
+    transcript.write_text("\n".join(lines) + "\n")
+
+    # Findings
+    findings = tmp_path / "findings.ndjson"
+    findings.write_text('{"type":"vuln"}\n{"type":"obs"}\n{"type":"obs"}\n')
+
+    # Endpoints
+    endpoints_dir = tmp_path / "interceptor"
+    endpoints_dir.mkdir()
+    (endpoints_dir / "endpoints.json").write_text(json.dumps([
+        {"endpoint": "GET /api/users", "seen": 5},
+        {"endpoint": "POST /api/login", "seen": 2},
+    ]))
+
+    ctx = build_resume_context(tmp_path)
+    assert ctx["engagement"] == "demo"
+    assert ctx["target"] == "https://x.com"
+    assert ctx["current_role"] == "admin"
+    assert ctx["last_turn"] == 15
+    assert ctx["findings_count"] == 3
+    assert ctx["endpoints_count"] == 2
+    assert "SQLi" in ctx["summary"]
+    assert len(ctx["recent_turns"]) == RESUME_TAIL_TURNS
+    assert len(ctx["endpoints_preview"]) == 2

--- a/tools/copilot/loop.py
+++ b/tools/copilot/loop.py
@@ -41,9 +41,16 @@ from typing import Any
 # Ensure the copilot tools directory is importable.
 sys.path.insert(0, str(Path(__file__).parent))
 
+from _auth import AuthManager, load_auth_config  # noqa: E402
 from _browser import BrowserWrapper  # noqa: E402
 from _primitives import PrimitiveError, run_http, run_note, run_shell  # noqa: E402
 from _rpc import make_server  # noqa: E402
+from _transcript import (  # noqa: E402
+    SummaryManager,
+    StateManager,
+    TranscriptWriter,
+    build_resume_context,
+)
 
 logger = logging.getLogger("copilot.loop")
 
@@ -80,8 +87,9 @@ def start_mitmdump(
 class Dispatcher:
     """Maps (primitive, action, args) to concrete calls.
 
-    Holds shared state: the BrowserWrapper, paths, turn counter, and
-    the asyncio event loop for browser calls from the sync RPC thread.
+    Holds shared state: the BrowserWrapper, auth manager, transcript
+    writer, summary manager, state manager, and the asyncio event loop
+    for browser calls from the sync RPC thread.
     """
 
     def __init__(
@@ -89,12 +97,17 @@ class Dispatcher:
         browser: BrowserWrapper,
         loop: asyncio.AbstractEventLoop,
         results_dir: Path,
+        auth_manager: AuthManager | None = None,
     ) -> None:
         self.browser = browser
         self.aio_loop = loop
         self.results_dir = results_dir
         self.copilot_dir = results_dir / "copilot"
-        self.turn = 0
+        self.auth = auth_manager
+        self.transcript = TranscriptWriter(self.copilot_dir)
+        self.summary = SummaryManager(self.copilot_dir)
+        self.state = StateManager(self.copilot_dir)
+        self.turn = self.transcript.turn_count  # Resume from existing count.
 
     def __call__(self, primitive: str, action: str, args: dict[str, Any]) -> dict[str, Any]:
         """Dispatch a single turn. Called from the RPC thread."""
@@ -102,24 +115,44 @@ class Dispatcher:
         ts = datetime.now(timezone.utc).isoformat()
 
         if primitive == "shutdown":
-            # Handled specially — signals the server to stop.
             raise SystemExit(0)
+
+        if primitive == "resume":
+            return build_resume_context(self.copilot_dir)
 
         try:
             result = self._dispatch(primitive, action, args)
         except PrimitiveError as exc:
             result = exc.to_dict()
 
-        # Annotate every response with turn metadata.
         result["turn"] = self.turn
         result["timestamp"] = ts
 
-        # Append to transcript.
-        self._log_turn(primitive, action, args, result, ts)
+        # Log to transcript.
+        self.transcript.append(
+            turn=self.turn,
+            primitive=primitive,
+            action=action,
+            args_summary=_summarize_args(args),
+            result_summary=result,
+        )
+
+        # Check if rolling summary is due.
+        if self.transcript.needs_summary():
+            endpoints_count = self._count_endpoints()
+            findings_count = self._count_lines(self.copilot_dir / "findings.ndjson")
+            tail = self.transcript.get_tail(10)
+            result["summary_prompt"] = self.summary.build_summary_prompt(
+                tail, findings_count, endpoints_count,
+            )
+
         return result
 
     def _dispatch(self, primitive: str, action: str, args: dict[str, Any]) -> dict[str, Any]:
         if primitive == "browser":
+            # Handle switch_role specially — needs auth manager.
+            if action == "switch_role":
+                return self._switch_role(args.get("role", "anonymous"))
             future = asyncio.run_coroutine_threadsafe(
                 self.browser.dispatch(action, args), self.aio_loop,
             )
@@ -140,7 +173,6 @@ class Dispatcher:
         if primitive == "shell":
             argv = args.get("argv")
             if argv is None:
-                # Also accept "cmd" as a string — split it.
                 cmd_str = args.get("cmd", "")
                 if not cmd_str:
                     raise PrimitiveError("bad_args", "shell requires 'argv' (list) or 'cmd' (string)")
@@ -149,10 +181,15 @@ class Dispatcher:
             return run_shell(argv, cwd=Path("/pentest-kit"))
 
         if primitive == "note":
+            note_type = args.get("type", "observation")
+            # Special: "summary" type writes to summary.md instead.
+            if note_type == "summary":
+                self.summary.write(args.get("title", ""))
+                return {"ok": True, "recorded": True, "type": "summary"}
             return run_note(
                 findings_path=self.copilot_dir / "findings.ndjson",
                 notes_path=self.copilot_dir / "notes.md",
-                type=args.get("type", "observation"),
+                type=note_type,
                 title=args.get("title", ""),
                 evidence=args.get("evidence"),
                 severity=args.get("severity"),
@@ -165,8 +202,12 @@ class Dispatcher:
                 "url": asyncio.run_coroutine_threadsafe(
                     self._get_url(), self.aio_loop,
                 ).result(timeout=5),
+                "current_role": self.state.read().get("current_role", "anonymous"),
                 "findings_count": self._count_lines(self.copilot_dir / "findings.ndjson"),
-                "transcript_lines": self._count_lines(self.copilot_dir / "transcript.ndjson"),
+                "transcript_lines": self.transcript.turn_count,
+                "endpoints_count": self._count_endpoints(),
+                "summary_preview": self.summary.read()[:500] or "(none)",
+                "auth_roles": self.auth.config.roles if self.auth else [],
             }
 
         return {
@@ -174,9 +215,53 @@ class Dispatcher:
             "error": {
                 "code": "unknown_primitive",
                 "message": f"unknown primitive: {primitive!r}. "
-                           f"Available: browser, http, shell, note, status, shutdown",
+                           f"Available: browser, http, shell, note, status, resume, shutdown",
             },
         }
+
+    def _switch_role(self, role: str) -> dict[str, Any]:
+        """Switch the browser session to a different authenticated role."""
+        if self.auth is None:
+            return {"ok": False, "error": {"code": "no_auth",
+                    "message": "No auth.yaml loaded — can't switch roles"}}
+
+        if not self.auth.has_session(role):
+            # Run login flow for this role.
+            async def _do_login() -> None:
+                async def ctx_factory():
+                    return await self.browser._browser.new_context(  # noqa: SLF001
+                        proxy={"server": f"http://127.0.0.1:{self.browser.proxy_port}"},
+                        ignore_https_errors=True,
+                    )
+                await self.auth.login(ctx_factory, role)
+
+            future = asyncio.run_coroutine_threadsafe(_do_login(), self.aio_loop)
+            future.result(timeout=60)
+
+        # Restart browser context with the role's storage_state.
+        session_path = self.auth.session_path(role)
+        if not session_path.exists():
+            return {"ok": False, "error": {"code": "no_session",
+                    "message": f"Session for role {role!r} not found after login"}}
+
+        async def _reload_context() -> dict[str, Any]:
+            # Close current context, create new one with storage_state.
+            if self.browser._context:  # noqa: SLF001
+                await self.browser._context.close()  # noqa: SLF001
+            self.browser._context = await self.browser._browser.new_context(  # noqa: SLF001
+                proxy={"server": f"http://127.0.0.1:{self.browser.proxy_port}"},
+                ignore_https_errors=True,
+                storage_state=str(session_path),
+                viewport={"width": 1280, "height": 720},
+            )
+            self.browser._page = await self.browser._context.new_page()  # noqa: SLF001
+            return await self.browser.navigate(self.state.read().get("target", ""))
+
+        future = asyncio.run_coroutine_threadsafe(_reload_context(), self.aio_loop)
+        result = future.result(timeout=60)
+        self.state.update({"current_role": role})
+        result["switched_to"] = role
+        return result
 
     async def _get_url(self) -> str:
         page = self.browser._page  # noqa: SLF001
@@ -188,30 +273,14 @@ class Dispatcher:
         with path.open() as f:
             return sum(1 for _ in f)
 
-    def _log_turn(
-        self,
-        primitive: str,
-        action: str,
-        args: dict[str, Any],
-        result: dict[str, Any],
-        ts: str,
-    ) -> None:
-        """Append a one-line entry to transcript.ndjson."""
-        transcript = self.copilot_dir / "transcript.ndjson"
-        transcript.parent.mkdir(parents=True, exist_ok=True)
-        entry = {
-            "turn": self.turn,
-            "timestamp": ts,
-            "primitive": primitive,
-            "action": action,
-            "args_summary": _summarize_args(args),
-            "ok": result.get("ok", False),
-            "url": result.get("url", ""),
-            "screenshot": result.get("screenshot"),
-            "error": result.get("error"),
-        }
-        with transcript.open("a") as f:
-            f.write(json.dumps(entry) + "\n")
+    def _count_endpoints(self) -> int:
+        ep_path = self.copilot_dir / "interceptor" / "endpoints.json"
+        if not ep_path.exists():
+            return 0
+        try:
+            return len(json.loads(ep_path.read_text()))
+        except (json.JSONDecodeError, ValueError):
+            return 0
 
 
 def _summarize_args(args: dict[str, Any]) -> dict[str, Any]:
@@ -236,6 +305,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--target", required=True, help="Target URL")
     parser.add_argument("--results", required=True, help="Results directory (container path)")
     parser.add_argument("--proxy-port", type=int, default=8081, help="mitmproxy listen port")
+    parser.add_argument("--resume", action="store_true", help="Resume from existing transcript + state")
     return parser.parse_args()
 
 
@@ -251,15 +321,37 @@ async def async_main(opts: argparse.Namespace) -> None:
     pid_file = copilot_dir / "loop.pid"
     pid_file.write_text(str(os.getpid()))
 
-    # Write state marker.
-    state_file = copilot_dir / "state.json"
-    state_file.write_text(json.dumps({
-        "engagement": opts.engagement,
-        "target": opts.target,
-        "started_at": datetime.now(timezone.utc).isoformat(),
-        "pid": os.getpid(),
-        "status": "starting",
-    }, indent=2))
+    # State management.
+    state_mgr = StateManager(copilot_dir)
+    if opts.resume:
+        logger.info("Resuming engagement %s", opts.engagement)
+        state_mgr.update({
+            "pid": os.getpid(),
+            "status": "resuming",
+            "resumed_at": datetime.now(timezone.utc).isoformat(),
+        })
+    else:
+        state_mgr.write({
+            "engagement": opts.engagement,
+            "target": opts.target,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "pid": os.getpid(),
+            "status": "starting",
+            "current_role": "anonymous",
+        })
+
+    # Load auth.yaml if present.
+    auth_path = results_dir / "auth.yaml"
+    auth_config = load_auth_config(auth_path)
+    auth_manager: AuthManager | None = None
+    if auth_config:
+        auth_manager = AuthManager(
+            config=auth_config,
+            sessions_dir=copilot_dir / "sessions",
+        )
+        logger.info("Loaded auth.yaml — roles: %s", auth_config.roles)
+    else:
+        logger.info("No auth.yaml found — running unauthenticated")
 
     # 1. Start mitmdump.
     mitm_proc = start_mitmdump(opts.proxy_port, copilot_dir / "interceptor", interceptor_path)
@@ -272,15 +364,26 @@ async def async_main(opts: argparse.Namespace) -> None:
     await browser.start()
 
     # Navigate to the target so the first turn has something to see.
-    await browser.navigate(opts.target)
+    if not opts.resume:
+        await browser.navigate(opts.target)
+    else:
+        # On resume, load the last known URL from state.
+        last_url = state_mgr.read().get("target", opts.target)
+        await browser.navigate(last_url)
+
+    # If auth.yaml present and resuming, restore the saved role's session.
+    if opts.resume and auth_manager:
+        current_role = state_mgr.read().get("current_role", "anonymous")
+        if auth_manager.has_session(current_role):
+            logger.info("Restoring session for role: %s", current_role)
 
     # Update state.
-    _update_state(state_file, {"status": "running"})
+    state_mgr.update({"status": "running"})
     logger.info("Loop ready. Socket: %s", socket_path)
 
     # 3. Start RPC server in a background thread.
     aio_loop = asyncio.get_running_loop()
-    dispatcher = Dispatcher(browser, aio_loop, results_dir)
+    dispatcher = Dispatcher(browser, aio_loop, results_dir, auth_manager=auth_manager)
     server = make_server(socket_path, dispatcher)
     rpc_thread = threading.Thread(target=server.serve_forever, daemon=True, name="rpc")
     rpc_thread.start()
@@ -308,20 +411,10 @@ async def async_main(opts: argparse.Namespace) -> None:
             mitm_proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             mitm_proc.kill()
-        _update_state(state_file, {"status": "stopped"})
+        state_mgr.update({"status": "stopped"})
         pid_file.unlink(missing_ok=True)
         socket_path.unlink(missing_ok=True)
         logger.info("Shutdown complete.")
-
-
-def _update_state(state_file: Path, updates: dict[str, Any]) -> None:
-    """Merge updates into state.json."""
-    try:
-        state = json.loads(state_file.read_text())
-    except (FileNotFoundError, json.JSONDecodeError):
-        state = {}
-    state.update(updates)
-    state_file.write_text(json.dumps(state, indent=2))
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Completes copilot V1 from epic #44. This PR adds the remaining pieces
that make copilot mode work on real targets (not just Juice Shop):

### T4: Authentication persistence (`_auth.py`)
- Loads `auth.yaml` from engagement dir
- Supports form/bearer/cookie login types
- Saves `storage_state.json` per role for resume
- Smart field filling: CSS selector → name → id → placeholder
- Switch roles mid-session: `browser switch_role`

### T5: Transcript + rolling summarization + resume
- `_transcript.py`: append-only NDJSON writer, summary manager (20-line
  cap, rewritten every 25 turns), state manager, resume context builder
- `copilot resume` CLI command: kills existing loop, restarts with
  `--resume` flag, loads state + summary + last 10 turns
- `resume` primitive returns full context as JSON

### Reasoning strategy (SKILL.md)
The most important part — tells the agent HOW TO THINK in copilot mode:
- 5-step turn loop: READ → DECIDE → EXECUTE → OBSERVE → SUMMARIZE
- Decision tree: mapping? testing hypothesis? stuck? wrong role?
- What to look for in observations (error msgs, status diffs, DOM changes)
- Anti-patterns: don't revisit, don't repeat inputs, don't forget roles
- Summary trigger instructions

### Loop integration
- Dispatcher wired to AuthManager, TranscriptWriter, SummaryManager, StateManager
- `note type="summary"` writes to summary.md
- `status` primitive shows current_role, endpoints, summary preview
- `--resume` flag on loop.py

## Tests
- 10 auth tests (config loading, credential lookup, session discovery)
- 18 transcript tests (writer, summary, state, resume context)
- **Total: 106 copilot tests passing** (78 from MVP + 28 new)

## Test plan
- [x] `go build ./...` + `go vet ./...` — clean
- [x] `go test ./...` — all Go tests pass
- [x] Python unit tests (106 passing in container)
- [ ] `pentest-kit copilot start demo` — needs rebuilt container
- [ ] End-to-end with `auth.yaml` against Juice Shop
- [ ] Resume after killing loop mid-session