### PR TITLE
feat(install): local dev installer with --symlink mode

### DIFF
--- a/install-local.sh
+++ b/install-local.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# pentest-kit LOCAL installer — for developers working from a git clone.
+#
+# Usage (from the repo root):
+#   ./install-local.sh                    # install to ~/.claude + build CLI + build Docker
+#   ./install-local.sh --skip-docker      # skip Docker image build
+#   ./install-local.sh --skip-cli         # skip Go CLI compilation
+#   ./install-local.sh --symlink          # symlink skill instead of copy (live edits)
+#
+# Options (env vars — same as install-remote.sh):
+#   CLAUDE_HOME=~/.claude-work            # install to specific Claude home
+#   CLAUDE_HOME=~/.claude,~/.claude-work  # install to multiple (comma-separated)
+#
+# What this does:
+#   1. Detects Claude home(s) — auto-detect or CLAUDE_HOME env
+#   2. Installs skill + agents to each Claude home (copy or symlink)
+#   3. Compiles Go CLI binary from pentest-kit-cli/ → installs to /usr/local/bin
+#   4. Builds Docker image locally (docker compose build)
+#   5. Sets up ~/.pentest-kit/ workspace (same as remote install)
+#
+# Why this exists:
+#   When developing pentest-kit, you need to test the skill against Claude Code.
+#   But the skill lives in ~/.claude/skills/ while the source is in the git clone.
+#   This script bridges that gap — especially with --symlink which makes
+#   ~/.claude/skills/pentest-kit → your clone, so edits are live.
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ─── Parse args ──────────────────────────────────────────────────────────
+
+SKIP_DOCKER=0
+SKIP_CLI=0
+USE_SYMLINK=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-docker)  SKIP_DOCKER=1 ;;
+        --skip-cli)     SKIP_CLI=1 ;;
+        --symlink)      USE_SYMLINK=1 ;;
+        --help|-h)
+            echo "Usage: ./install-local.sh [--skip-docker] [--skip-cli] [--symlink]"
+            echo ""
+            echo "  --skip-docker   Skip Docker image build"
+            echo "  --skip-cli      Skip Go CLI compilation"
+            echo "  --symlink       Symlink skill dir instead of copy (live edits)"
+            echo ""
+            echo "Env vars:"
+            echo "  CLAUDE_HOME=~/.claude-work   Install to specific Claude home"
+            exit 0
+            ;;
+    esac
+done
+
+# ─── Locate repo root ───────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+
+if [ ! -f "$REPO_ROOT/CLAUDE.md" ] || [ ! -d "$REPO_ROOT/.claude/skills/pentest-kit" ]; then
+    echo -e "${RED}[ERROR]${NC} Run this script from the pentest-kit repo root."
+    echo "  Expected: $REPO_ROOT/CLAUDE.md and $REPO_ROOT/.claude/skills/pentest-kit/"
+    exit 1
+fi
+
+echo ""
+echo -e "${BOLD}${CYAN}==========================================${NC}"
+echo -e "${BOLD}${CYAN}  pentest-kit local installer${NC}"
+echo -e "${BOLD}${CYAN}==========================================${NC}"
+echo -e "  Source: ${GREEN}$REPO_ROOT${NC}"
+echo -e "  Mode:   ${GREEN}$([ "$USE_SYMLINK" = 1 ] && echo 'symlink (live edits)' || echo 'copy')${NC}"
+echo ""
+
+# ─── Claude home detection (shared with install-remote.sh) ───────────────
+
+detect_claude_homes() {
+    local homes=()
+    for d in "$HOME"/.claude "$HOME"/.claude-*; do
+        if [ -d "$d" ] && { [ -f "$d/settings.json" ] || [ -f "$d/settings.local.json" ] || [ -d "$d/skills" ]; }; then
+            homes+=("$d")
+        fi
+    done
+    if [ ${#homes[@]} -eq 0 ] && [ -d "$HOME/.claude" ]; then
+        homes=("$HOME/.claude")
+    fi
+    printf '%s\n' "${homes[@]}"
+}
+
+pick_claude_homes() {
+    if [ -n "${CLAUDE_HOME:-}" ]; then
+        IFS=',' read -ra SELECTED_HOMES <<< "$CLAUDE_HOME"
+        return
+    fi
+
+    mapfile -t ALL_HOMES < <(detect_claude_homes)
+
+    if [ ${#ALL_HOMES[@]} -eq 0 ]; then
+        echo -e "  ${RED}[ERROR]${NC} No Claude Code home found (~/.claude or ~/.claude-*)."
+        exit 1
+    fi
+
+    if [ ${#ALL_HOMES[@]} -eq 1 ]; then
+        SELECTED_HOMES=("${ALL_HOMES[0]}")
+        return
+    fi
+
+    echo -e "  ${CYAN}Detected multiple Claude Code homes:${NC}"
+    for i in "${!ALL_HOMES[@]}"; do
+        echo -e "    $((i+1)). ${ALL_HOMES[$i]}"
+    done
+    echo -e "    $((${#ALL_HOMES[@]}+1)). All of the above"
+    echo ""
+    read -rp "  Install to [1-$((${#ALL_HOMES[@]}+1))]: " choice
+    if [ "$choice" -eq "$((${#ALL_HOMES[@]}+1))" ] 2>/dev/null; then
+        SELECTED_HOMES=("${ALL_HOMES[@]}")
+    elif [ "$choice" -ge 1 ] 2>/dev/null && [ "$choice" -le "${#ALL_HOMES[@]}" ] 2>/dev/null; then
+        SELECTED_HOMES=("${ALL_HOMES[$((choice-1))]}")
+    else
+        echo -e "  ${RED}[ERROR]${NC} Invalid choice."
+        exit 1
+    fi
+}
+
+SELECTED_HOMES=()
+pick_claude_homes
+
+echo -e "${BOLD}[1/5] Claude homes: ${#SELECTED_HOMES[@]}${NC}"
+for h in "${SELECTED_HOMES[@]}"; do echo -e "  → $h"; done
+
+# ─── Step 2: Install skill + agents ─────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}[2/5] Installing skill + agents...${NC}"
+
+install_to_home() {
+    local claude_home="$1"
+    local skill_dir="$claude_home/skills/pentest-kit"
+    local agents_dir="$claude_home/agents"
+
+    echo -e "  ${CYAN}$claude_home${NC}"
+
+    # Backup existing (only if it's not already a symlink to us)
+    if [ -d "$skill_dir" ] && [ ! -L "$skill_dir" ]; then
+        backup="$skill_dir.backup.$(date +%s)"
+        mv "$skill_dir" "$backup"
+        echo -e "    ${YELLOW}[BACKUP]${NC} → $(basename "$backup")"
+    elif [ -L "$skill_dir" ]; then
+        rm "$skill_dir"
+    fi
+
+    if [ "$USE_SYMLINK" = 1 ]; then
+        # Symlink: skill dir → repo's .claude/skills/pentest-kit
+        mkdir -p "$(dirname "$skill_dir")"
+        ln -sf "$REPO_ROOT/.claude/skills/pentest-kit" "$skill_dir"
+        echo -e "    ${GREEN}[SYMLINK]${NC} $skill_dir → repo"
+    else
+        # Copy
+        mkdir -p "$skill_dir"
+        cp -r "$REPO_ROOT/.claude/skills/pentest-kit/"* "$skill_dir/"
+        echo -e "    ${GREEN}[COPY]${NC} Skill installed"
+    fi
+
+    # Agents — always copy (symlinks for individual .md files are messy)
+    mkdir -p "$agents_dir"
+    if [ -d "$REPO_ROOT/.claude/agents" ]; then
+        for agent in "$REPO_ROOT/.claude/agents/"*.md; do
+            [ -f "$agent" ] || continue
+            name=$(basename "$agent")
+            dst="$agents_dir/$name"
+            if [ -f "$dst" ] && ! grep -q "Pentest-Kit" "$dst" 2>/dev/null; then
+                dst="$agents_dir/pentest-kit-$name"
+            fi
+            cp "$agent" "$dst"
+        done
+        echo -e "    ${GREEN}[OK]${NC} Agents installed"
+    fi
+
+    # Per-home config
+    local cfg_dir="$skill_dir"
+    [ -L "$skill_dir" ] && cfg_dir="$REPO_ROOT/.claude/skills/pentest-kit"
+    cat > "$cfg_dir/.pentest-kit-config" << CFGEOF
+{
+  "installed_at": "$(date -u '+%Y-%m-%dT%H:%M:%SZ')",
+  "version": "local-dev",
+  "method": "local",
+  "source": "$REPO_ROOT",
+  "symlink": $USE_SYMLINK,
+  "claude_home": "$claude_home"
+}
+CFGEOF
+}
+
+for home in "${SELECTED_HOMES[@]}"; do
+    install_to_home "$home"
+done
+
+# ─── Step 3: Compile Go CLI ─────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}[3/5] Go CLI...${NC}"
+
+if [ "$SKIP_CLI" = 1 ]; then
+    echo -e "  ${YELLOW}[SKIP]${NC} --skip-cli"
+else
+    if ! command -v go &>/dev/null; then
+        echo -e "  ${YELLOW}[SKIP]${NC} Go not installed — install from https://go.dev/dl/"
+    else
+        echo -e "  ${YELLOW}[BUILDING]${NC} pentest-kit CLI..."
+        VERSION=$(git -C "$REPO_ROOT" describe --tags --always 2>/dev/null || echo "local-dev")
+        LDFLAGS="-s -w -X main.version=${VERSION}"
+
+        (cd "$REPO_ROOT/pentest-kit-cli" && \
+            go build -ldflags "$LDFLAGS" -trimpath -o pentest-kit ./cmd/pentest-kit/) 2>&1
+
+        if [ $? -eq 0 ]; then
+            CLI_BIN="$REPO_ROOT/pentest-kit-cli/pentest-kit"
+            chmod +x "$CLI_BIN"
+
+            # Install to /usr/local/bin
+            if [ -w /usr/local/bin ]; then
+                cp "$CLI_BIN" /usr/local/bin/pentest-kit
+            elif command -v sudo &>/dev/null; then
+                sudo cp "$CLI_BIN" /usr/local/bin/pentest-kit
+                sudo chmod +x /usr/local/bin/pentest-kit
+            else
+                mkdir -p "$HOME/.local/bin"
+                cp "$CLI_BIN" "$HOME/.local/bin/pentest-kit"
+                echo -e "  ${YELLOW}[NOTE]${NC} Installed to ~/.local/bin — ensure it's in PATH"
+            fi
+            echo -e "  ${GREEN}[OK]${NC} pentest-kit $VERSION → $(which pentest-kit 2>/dev/null || echo "$HOME/.local/bin/pentest-kit")"
+        else
+            echo -e "  ${RED}[FAIL]${NC} Go build failed — check errors above"
+        fi
+    fi
+fi
+
+# ─── Step 4: Docker workspace + build ───────────────────────────────────
+
+echo ""
+echo -e "${BOLD}[4/5] Docker...${NC}"
+
+# Set up ~/.pentest-kit/ workspace — points to the clone for docker-compose.yml
+WORK_DIR="$HOME/.pentest-kit"
+mkdir -p "$WORK_DIR"
+
+# Instead of copying docker files, symlink to the repo so `docker compose build`
+# uses the latest source. If symlink exists, skip.
+for f in docker-compose.yml Dockerfile docker-entrypoint.sh .dockerignore; do
+    target="$WORK_DIR/$f"
+    if [ -f "$REPO_ROOT/$f" ]; then
+        rm -f "$target"
+        ln -sf "$REPO_ROOT/$f" "$target"
+    fi
+done
+
+# Symlink directories docker-compose.yml references
+for d in tools .claude rules rules.local; do
+    target="$WORK_DIR/$d"
+    if [ -d "$REPO_ROOT/$d" ]; then
+        rm -rf "$target"
+        ln -sf "$REPO_ROOT/$d" "$target"
+    fi
+done
+
+# Copy docs needed by Dockerfile COPY instruction
+for f in README.md CLAUDE.md; do
+    if [ -f "$REPO_ROOT/$f" ]; then
+        cp "$REPO_ROOT/$f" "$WORK_DIR/"
+    fi
+done
+
+mkdir -p "$WORK_DIR/targets" "$WORK_DIR/results"
+echo -e "  ${GREEN}[OK]${NC} Workspace → $WORK_DIR (symlinked to repo)"
+
+if [ "$SKIP_DOCKER" = 1 ]; then
+    echo -e "  ${YELLOW}[SKIP]${NC} Docker build (--skip-docker)"
+else
+    if ! command -v docker &>/dev/null; then
+        echo -e "  ${YELLOW}[SKIP]${NC} Docker not installed"
+    else
+        echo -e "  ${YELLOW}[BUILDING]${NC} Docker image (this takes a while)..."
+        # Build from the repo root (where Dockerfile is), not ~/.pentest-kit
+        if (cd "$REPO_ROOT" && docker compose build 2>&1 | tail -5); then
+            echo -e "  ${GREEN}[OK]${NC} Docker image built"
+        else
+            echo -e "  ${YELLOW}[WARN]${NC} Docker build failed — check network/Dockerfile"
+            echo "  You can retry with: cd $REPO_ROOT && docker compose build"
+        fi
+    fi
+fi
+
+# ─── Step 5: Run tests ──────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}[5/5] Verification...${NC}"
+
+if command -v go &>/dev/null && [ "$SKIP_CLI" != 1 ]; then
+    echo -e "  ${YELLOW}[TESTING]${NC} Go tests..."
+    if (cd "$REPO_ROOT/pentest-kit-cli" && go test ./... -count=1 2>&1 | tail -5); then
+        echo -e "  ${GREEN}[OK]${NC} Go tests pass"
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} Go tests failed"
+    fi
+fi
+
+if command -v pentest-kit &>/dev/null; then
+    echo -e "  ${GREEN}[OK]${NC} CLI: $(pentest-kit --version 2>&1)"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}${CYAN}==========================================${NC}"
+echo -e "${BOLD}${CYAN}  pentest-kit local install complete${NC}"
+echo -e "${BOLD}${CYAN}==========================================${NC}"
+echo ""
+for home in "${SELECTED_HOMES[@]}"; do
+    mode="copy"
+    [ "$USE_SYMLINK" = 1 ] && mode="symlink"
+    echo -e "  Claude:    ${GREEN}$home${NC} ($mode)"
+done
+echo -e "  Workspace: ${GREEN}$WORK_DIR${NC}"
+echo -e "  Source:    ${GREEN}$REPO_ROOT${NC}"
+echo ""
+echo -e "  ${BOLD}Dev workflow:${NC}"
+if [ "$USE_SYMLINK" = 1 ]; then
+    echo "    Edit files in the repo → changes are live in Claude Code"
+    echo "    Rebuild CLI after Go changes:  cd pentest-kit-cli && go build -o pentest-kit ./cmd/pentest-kit/ && sudo cp pentest-kit /usr/local/bin/"
+    echo "    Rebuild Docker after changes:  cd $REPO_ROOT && docker compose build"
+else
+    echo "    After editing, re-run: ./install-local.sh --skip-docker"
+    echo "    Or use --symlink for live edits: ./install-local.sh --symlink"
+fi
+echo ""
+echo -e "  ${BOLD}Quick test:${NC}"
+echo "    pentest-kit up && pentest-kit preflight"
+echo ""


### PR DESCRIPTION
## Summary

`install-local.sh` for developers working from a git clone. The key problem: you edit SKILL.md or copilot Python files in the repo, but Claude Code reads from `~/.claude/skills/pentest-kit/` — so you have to manually copy files every time you want to test.

**`--symlink` mode** solves this:
```bash
./install-local.sh --symlink
# → ~/.claude/skills/pentest-kit → /path/to/clone/.claude/skills/pentest-kit
# Edit anything → Claude Code sees it immediately
```

Also:
- Compiles Go CLI from source, installs to /usr/local/bin
- Builds Docker image from local Dockerfile
- Shares CLAUDE_HOME multi-profile detection from install-remote.sh
- Runs Go tests as verification
- Docker workspace (~/.pentest-kit/) symlinks to repo files

## Test plan
- [ ] `bash -n install-local.sh` — syntax OK
- [ ] `./install-local.sh --symlink --skip-docker` — skill symlinked, CLI built
- [ ] `ls -la ~/.claude/skills/pentest-kit` — shows symlink
- [ ] Edit SKILL.md in repo → visible in `~/.claude/skills/pentest-kit/SKILL.md`
- [ ] `CLAUDE_HOME=~/.claude-work ./install-local.sh --skip-docker --skip-cli` — non-default home