### PR TITLE
fix(docker): push dev-tagged images to GHCR + fix backup location

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
@@ -90,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/install-local.sh
+++ b/install-local.sh
@@ -145,11 +145,15 @@ install_to_home() {
 
     echo -e "  ${CYAN}$claude_home${NC}"
 
-    # Backup existing (only if it's not already a symlink to us)
+    # Backup existing (only if it's not already a symlink to us).
+    # Backups go to ~/.pentest-kit/backups/ — NOT inside ~/.claude/skills/
+    # because Claude Code scans skills/ and would load the backup as a second skill.
     if [ -d "$skill_dir" ] && [ ! -L "$skill_dir" ]; then
-        backup="$skill_dir.backup.$(date +%s)"
-        mv "$skill_dir" "$backup"
-        echo -e "    ${YELLOW}[BACKUP]${NC} → $(basename "$backup")"
+        backup_dir="$HOME/.pentest-kit/backups"
+        mkdir -p "$backup_dir"
+        backup_name="$(basename "$claude_home")-pentest-kit.backup.$(date +%s)"
+        mv "$skill_dir" "$backup_dir/$backup_name"
+        echo -e "    ${YELLOW}[BACKUP]${NC} → $backup_dir/$backup_name"
     elif [ -L "$skill_dir" ]; then
         rm "$skill_dir"
     fi

--- a/install-remote.sh
+++ b/install-remote.sh
@@ -219,11 +219,14 @@ install_skill_to_home() {
 
     echo -e "  ${CYAN}Installing to: $claude_home${NC}"
 
-    # Backup existing
+    # Backup existing — store in ~/.pentest-kit/backups/, NOT inside skills/
+    # (Claude Code scans skills/ and would load the backup as a duplicate skill)
     if [ -d "$skill_dir" ]; then
-        backup="$skill_dir.backup.$(date +%s)"
-        mv "$skill_dir" "$backup"
-        echo -e "    ${YELLOW}[BACKUP]${NC} Existing skill → $(basename $backup)"
+        backup_dir="$HOME/.pentest-kit/backups"
+        mkdir -p "$backup_dir"
+        backup_name="$(basename "$claude_home")-pentest-kit.backup.$(date +%s)"
+        mv "$skill_dir" "$backup_dir/$backup_name"
+        echo -e "    ${YELLOW}[BACKUP]${NC} → $backup_dir/$backup_name"
     fi
 
     # Install skill


### PR DESCRIPTION
## Summary

Two fixes:

1. **Docker dev images now push to GHCR** — dev branch builds were succeeding but never pushing because `push:` was gated to `refs/heads/main`. Now dev pushes tag `dev`, main pushes tag `latest`. Users can: `docker pull ghcr.io/nunenuh/pentest-kit:dev`

2. **Skill backups moved out of skills/** — both installers were putting backups at `~/.claude/skills/pentest-kit.backup.TIMESTAMP`, which Claude Code scanned and loaded as a duplicate skill (the first line in the screenshot showed `/pentest-kit.backup.1775780519`). Now backups go to `~/.pentest-kit/backups/`.

## Test plan
- [ ] Merge → Docker CI builds and pushes with `:dev` tag
- [ ] `docker pull ghcr.io/nunenuh/pentest-kit:dev` works
- [ ] `./install-local.sh --symlink --skip-docker` puts backups in `~/.pentest-kit/backups/`, not `~/.claude/skills/`
- [ ] No duplicate skill names in Claude Code UI