### PR TITLE
fix(exec): auto-wrap piped commands in bash -c #57

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -139,15 +139,21 @@ pentest-kit exec nuclei -u https://target.com -t /pentest-kit/rules/nuclei/ -t /
 
 Examples:
 ```bash
-# Save nmap output to engagement scans dir
+# Simple command — no pipes, runs directly
 pentest-kit exec nmap -sV target.com -oX /pentest-kit/results/my-eng/scans/reconnaissance/raw/nmap.xml
 
 # Run with proxy
 pentest-kit exec proxychains4 -q nuclei -u https://target.com -jsonl -o /pentest-kit/results/my-eng/scans/vulnerability/nuclei/nuclei-full.json
 
-# Complex commands
+# IMPORTANT: Commands with pipes, redirects, or chaining MUST use bash -c
+# The CLI auto-wraps when it detects |, >, &&, ; but always prefer explicit bash -c
 pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json -o /pentest-kit/results/my-eng/scans/reconnaissance/raw/httpx.json"
+pentest-kit exec bash -c "curl -s http://target/api/users 2>&1 | head -50"
+pentest-kit exec bash -c "nmap -sV target.com && echo done"
 ```
+
+**CRITICAL: Always use `bash -c "..."` for piped or chained commands.** Without it,
+shell operators are parsed by the HOST shell and never reach the container.
 
 ## Core Principles
 

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -173,16 +173,51 @@ func execCmd() *cobra.Command {
 				return err
 			}
 			// Handle --no-proxy flag (since DisableFlagParsing is true, parse manually)
+			noProxy := false
+			execArgs := args
 			if args[0] == "--no-proxy" || args[0] == "--direct" {
 				if len(args) < 2 {
 					return fmt.Errorf("usage: pentest-kit exec --no-proxy <command>")
 				}
-				// Set env var so proxychains is skipped inside container
-				return docker.ExecWithEnv(ws, args[1:], []string{"PENTEST_KIT_NO_PROXY=1"})
+				noProxy = true
+				execArgs = args[1:]
 			}
-			return docker.Exec(ws, args)
+
+			// Auto-wrap in bash -c if shell operators are detected.
+			// Without this, pipes/redirects are parsed by the HOST shell
+			// and never reach the container — causing silent failures.
+			execArgs = autoWrapShellCmd(execArgs)
+
+			if noProxy {
+				return docker.ExecWithEnv(ws, execArgs, []string{"PENTEST_KIT_NO_PROXY=1"})
+			}
+			return docker.Exec(ws, execArgs)
 		},
 	}
+}
+
+// autoWrapShellCmd detects shell operators (|, >, >>, &&, ;) in the args
+// and wraps the entire command in bash -c "..." so they execute inside the
+// container, not on the host. Without this, `pentest-kit exec curl ... | head`
+// silently fails because the pipe is parsed by the host shell.
+func autoWrapShellCmd(args []string) []string {
+	// Already wrapped — don't double-wrap.
+	if len(args) >= 2 && args[0] == "bash" && args[1] == "-c" {
+		return args
+	}
+	for _, a := range args {
+		if a == "|" || a == ">" || a == ">>" || a == "&&" || a == ";" || a == "||" {
+			// Join all args into a single bash -c command.
+			joined := strings.Join(args, " ")
+			return []string{"bash", "-c", joined}
+		}
+		// Also check for inline pipes/redirects within a single arg
+		if strings.Contains(a, "|") || strings.Contains(a, ">>") {
+			joined := strings.Join(args, " ")
+			return []string{"bash", "-c", joined}
+		}
+	}
+	return args
 }
 
 // pentest-kit preflight [--deep] [--save]


### PR DESCRIPTION
Closes #57. Auto-detects shell operators and wraps in bash -c. SKILL.md updated.