### PR TITLE
Release v0.13.1 — fix exec pipe auto-wrap #57

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -139,15 +139,21 @@ pentest-kit exec nuclei -u https://target.com -t /pentest-kit/rules/nuclei/ -t /
 
 Examples:
 ```bash
-# Save nmap output to engagement scans dir
+# Simple command — no pipes, runs directly
 pentest-kit exec nmap -sV target.com -oX /pentest-kit/results/my-eng/scans/reconnaissance/raw/nmap.xml
 
 # Run with proxy
 pentest-kit exec proxychains4 -q nuclei -u https://target.com -jsonl -o /pentest-kit/results/my-eng/scans/vulnerability/nuclei/nuclei-full.json
 
-# Complex commands
+# IMPORTANT: Commands with pipes, redirects, or chaining MUST use bash -c
+# The CLI auto-wraps when it detects |, >, &&, ; but always prefer explicit bash -c
 pentest-kit exec bash -c "subfinder -d target.com -silent | httpx -silent -json -o /pentest-kit/results/my-eng/scans/reconnaissance/raw/httpx.json"
+pentest-kit exec bash -c "curl -s http://target/api/users 2>&1 | head -50"
+pentest-kit exec bash -c "nmap -sV target.com && echo done"
 ```
+
+**CRITICAL: Always use `bash -c "..."` for piped or chained commands.** Without it,
+shell operators are parsed by the HOST shell and never reach the container.
 
 ## Core Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,36 @@
-# [0.13.0-dev.10](https://github.com/nunenuh/pentest-kit/compare/v0.13.0-dev.9...v0.13.0-dev.10) (2026-04-10)
+# [0.13.0](https://github.com/nunenuh/pentest-kit/compare/v0.12.1...v0.13.0) (2026-04-10)
 
 
 ### Bug Fixes
 
-* **exec:** auto-wrap piped commands in bash -c [#57](https://github.com/nunenuh/pentest-kit/issues/57) ([1fa8b8b](https://github.com/nunenuh/pentest-kit/commit/1fa8b8b9dd3cdd8a6b809920d6bc976f1a52dfc9))
+* **copilot:** SPA-compatible auth login + domcontentloaded waits [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([a7d6e60](https://github.com/nunenuh/pentest-kit/commit/a7d6e6013147ba2167e23eec3a55001441f9f8e1))
+* **docker:** link Playwright CLI for Python + fix smoke test timing [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([6eed3db](https://github.com/nunenuh/pentest-kit/commit/6eed3db67b12d7de3f88fd2b5fae73977ff95a76))
+* **docker:** push dev-tagged images to GHCR + fix backup location [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([5a949db](https://github.com/nunenuh/pentest-kit/commit/5a949db6ef8e64a7f910b82a2d682c8af5572fc5))
+* **docker:** use PENTEST_KIT_TAG env for image tag, default to latest ([91d64b8](https://github.com/nunenuh/pentest-kit/commit/91d64b867cd7f5aee3247995906e794181eb8792))
+* **proxy:** isolate container PID, detect host tor, safe stop [#42](https://github.com/nunenuh/pentest-kit/issues/42) ([442927d](https://github.com/nunenuh/pentest-kit/commit/442927ddccecc3c2597101bf2b3e57d602061f44))
+* **proxy:** start tor as real daemon, verify SOCKS5 round-trip [#42](https://github.com/nunenuh/pentest-kit/issues/42) ([8829814](https://github.com/nunenuh/pentest-kit/commit/882981400a9eb860fef268ada20ecc15e2c35c9d))
+* **scan:** robust pipelines with timeouts + docs update for release ([faa40f3](https://github.com/nunenuh/pentest-kit/commit/faa40f33bb5e0f696c527034ff7e58e6f8f220fa))
+
+
+### Features
+
+* **attacks:** T1-T4 — WSTG reasoning strategy + quality fixes [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([0112f64](https://github.com/nunenuh/pentest-kit/commit/0112f6491f2adb6ed5bbe8313f564f20de216db4))
+* **attacks:** T5 — rewrite ATTACK_INDEX.md with WSTG coverage map [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([e75c6a2](https://github.com/nunenuh/pentest-kit/commit/e75c6a20ec52739253546cb68d3aada2043ad970))
+* **attacks:** T6-T18 — 26 new WSTG attack docs + modern vectors [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([b90cc76](https://github.com/nunenuh/pentest-kit/commit/b90cc76625f10fcdb76b1d8b4cf54ce359ad4294))
+* **copilot:** auth persistence + transcript/resume system [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([c4666c6](https://github.com/nunenuh/pentest-kit/commit/c4666c6ba2097ef56d21a7ebe0736b562f94d90b))
+* **copilot:** browser wrapper + loop orchestrator + interceptor T3 [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([6653a91](https://github.com/nunenuh/pentest-kit/commit/6653a916aca89186904d926fb79bf0e9e4f67dfb))
+* **copilot:** Go CLI wiring + SKILL.md rewrite + COPILOT.md spec [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([4346ce6](https://github.com/nunenuh/pentest-kit/commit/4346ce6488012a931df0c9eabb3a9856545ee5db))
+* **copilot:** guardrails + DOM summarizer (MVP building blocks) [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([a13cfee](https://github.com/nunenuh/pentest-kit/commit/a13cfee6933a25320d9075f309a9beaa44b3b216))
+* **copilot:** line-delimited JSON-RPC over UNIX socket [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([d7301d4](https://github.com/nunenuh/pentest-kit/commit/d7301d4261846656a5c514098c13634e2a1aaac6))
+* **copilot:** shell/http/note primitives with 21 tests [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([1b5ffe1](https://github.com/nunenuh/pentest-kit/commit/1b5ffe1cdff2c23df85178ab4a6e68dd9d2354a3))
+* **copilot:** T22 replay CLI + T23 integration smoke test [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([5e0dac7](https://github.com/nunenuh/pentest-kit/commit/5e0dac7ca9077620c43f80ddfb790058eb53c399))
+* **copilot:** wire auth + transcript into loop, resume CLI, reasoning strategy [#44](https://github.com/nunenuh/pentest-kit/issues/44) ([1336f29](https://github.com/nunenuh/pentest-kit/commit/1336f29a5abff76f25220c018b262426275462a9))
+* **install:** add install-local.sh for dev workflow [#46](https://github.com/nunenuh/pentest-kit/issues/46) ([880c0df](https://github.com/nunenuh/pentest-kit/commit/880c0dfea661c3b544b072f2cf64fb7b04224de0))
+* **install:** dev release binaries + dev-latest install option [#46](https://github.com/nunenuh/pentest-kit/issues/46) ([29db3d4](https://github.com/nunenuh/pentest-kit/commit/29db3d47dc904f931dfeecc197d2d27746b622ed))
+* **install:** support CLAUDE_HOME for multi-profile setups [#46](https://github.com/nunenuh/pentest-kit/issues/46) ([053b896](https://github.com/nunenuh/pentest-kit/commit/053b896686310727f548706ce9b834b68d801d39))
+* **install:** support PENTEST_KIT_VERSION=dev for dev branch install [#46](https://github.com/nunenuh/pentest-kit/issues/46) ([695a048](https://github.com/nunenuh/pentest-kit/commit/695a0485b81fa2f1d822ddcd9a6bbf64b094711a))
+* **preflight:** add copilot mode readiness checks [#51](https://github.com/nunenuh/pentest-kit/issues/51) ([c48eb97](https://github.com/nunenuh/pentest-kit/commit/c48eb97411b15638a0569c7f07c032cebaa64790))
+* **proxy:** add presets, honest selection docs [#42](https://github.com/nunenuh/pentest-kit/issues/42) ([6a6671f](https://github.com/nunenuh/pentest-kit/commit/6a6671fee181a67b69c3439692a1fcce0f96ca83))
 
 # [0.13.0-dev.9](https://github.com/nunenuh/pentest-kit/compare/v0.13.0-dev.8...v0.13.0-dev.9) (2026-04-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.13.0-dev.10](https://github.com/nunenuh/pentest-kit/compare/v0.13.0-dev.9...v0.13.0-dev.10) (2026-04-10)
+
+
+### Bug Fixes
+
+* **exec:** auto-wrap piped commands in bash -c [#57](https://github.com/nunenuh/pentest-kit/issues/57) ([1fa8b8b](https://github.com/nunenuh/pentest-kit/commit/1fa8b8b9dd3cdd8a6b809920d6bc976f1a52dfc9))
+
 # [0.13.0-dev.9](https://github.com/nunenuh/pentest-kit/compare/v0.13.0-dev.8...v0.13.0-dev.9) (2026-04-10)
 
 

--- a/pentest-kit-cli/cmd/pentest-kit/main.go
+++ b/pentest-kit-cli/cmd/pentest-kit/main.go
@@ -173,16 +173,51 @@ func execCmd() *cobra.Command {
 				return err
 			}
 			// Handle --no-proxy flag (since DisableFlagParsing is true, parse manually)
+			noProxy := false
+			execArgs := args
 			if args[0] == "--no-proxy" || args[0] == "--direct" {
 				if len(args) < 2 {
 					return fmt.Errorf("usage: pentest-kit exec --no-proxy <command>")
 				}
-				// Set env var so proxychains is skipped inside container
-				return docker.ExecWithEnv(ws, args[1:], []string{"PENTEST_KIT_NO_PROXY=1"})
+				noProxy = true
+				execArgs = args[1:]
 			}
-			return docker.Exec(ws, args)
+
+			// Auto-wrap in bash -c if shell operators are detected.
+			// Without this, pipes/redirects are parsed by the HOST shell
+			// and never reach the container — causing silent failures.
+			execArgs = autoWrapShellCmd(execArgs)
+
+			if noProxy {
+				return docker.ExecWithEnv(ws, execArgs, []string{"PENTEST_KIT_NO_PROXY=1"})
+			}
+			return docker.Exec(ws, execArgs)
 		},
 	}
+}
+
+// autoWrapShellCmd detects shell operators (|, >, >>, &&, ;) in the args
+// and wraps the entire command in bash -c "..." so they execute inside the
+// container, not on the host. Without this, `pentest-kit exec curl ... | head`
+// silently fails because the pipe is parsed by the host shell.
+func autoWrapShellCmd(args []string) []string {
+	// Already wrapped — don't double-wrap.
+	if len(args) >= 2 && args[0] == "bash" && args[1] == "-c" {
+		return args
+	}
+	for _, a := range args {
+		if a == "|" || a == ">" || a == ">>" || a == "&&" || a == ";" || a == "||" {
+			// Join all args into a single bash -c command.
+			joined := strings.Join(args, " ")
+			return []string{"bash", "-c", joined}
+		}
+		// Also check for inline pipes/redirects within a single arg
+		if strings.Contains(a, "|") || strings.Contains(a, ">>") {
+			joined := strings.Join(args, " ")
+			return []string{"bash", "-c", joined}
+		}
+	}
+	return args
 }
 
 // pentest-kit preflight [--deep] [--save]


### PR DESCRIPTION
Auto-wraps piped commands in bash -c. Fixes exit code 7 on pentest-kit exec with pipes.